### PR TITLE
Add Puara Shake gesture processor

### DIFF
--- a/Puara/Shake.cpp
+++ b/Puara/Shake.cpp
@@ -3,6 +3,42 @@ namespace puara_gestures::objects
 {
 void Shake::operator()(halp::tick t)
 {
+
+  // getting input data
+
+  const puara_gestures::Coord3D & current_accel = inputs.accel.value;
+  const float desired_frequency = inputs.integrator_frequency.value;
+
+  // updating puara parameters
+
+  //checking if the desired frequency for the integrator has changed
+  if(impl.x.frequency()!= desired_frequency){
+    impl.frequency(desired_frequency); // setting the freq for x,y,z
+  }
+
+
+  //3.updating the puara gestures implementation
+  impl.update(current_accel.x,current_accel.y,current_accel.z);
+
+  //4.getting processed value from puara
+  puara_gestures::Coord3D shake_vector = impl.current_value();
+
+  //5. calculating the desired float value
+
+  float shake_magnitude = std::sqrt((shake_vector.x * shake_vector.x) +
+      (shake_vector.y * shake_vector.y) +
+      (shake_vector.z * shake_vector.z));
+
+  //6 setting the output port value
+
+  outputs.output.value = shake_magnitude;
+  printf("Shake Accel: (%.2f, %.2f, %.2f), Freq: %.2f | PuaraVec: (%.2f, %.2f, %.2f) | Mag: %.2f\n",
+         current_accel.x, current_accel.y, current_accel.z,
+         desired_frequency,
+         shake_vector.x, shake_vector.y, shake_vector.z,
+         shake_magnitude);
+
+
   // TODO
   // outputs.output = impl.shake(inputs.accel, inputs.gyro, inputs.mag, 0.1);
 }

--- a/Puara/Shake.hpp
+++ b/Puara/Shake.hpp
@@ -18,8 +18,10 @@ public:
   struct ins
   {
     halp::val_port<"Acceleration", puara_gestures::Coord3D> accel;
-    halp::val_port<"Gyrosocope", puara_gestures::Coord3D> gyro;
-    halp::val_port<"Magnetometer", puara_gestures::Coord3D> mag;
+    // halp::val_port<"Gyrosocope", puara_gestures::Coord3D> gyro;
+    // halp::val_port<"Magnetometer", puara_gestures::Coord3D> mag;
+
+    halp::val_port<"Integrator Frequency",float>integrator_frequency{10.0f};
   } inputs;
 
   struct
@@ -33,7 +35,7 @@ public:
   using tick = halp::tick;
   void operator()(halp::tick t);
 
-  puara_gestures::Shake impl;
+  puara_gestures::Shake3D impl;
 };
 
 }


### PR DESCRIPTION
Implements Shake gesture processor using Avendish wrapper for puara_gestures::Shake3D. Takes 3D accelerometer input and outputs a float representing shake magnitude.