### PR TITLE
feat: Add Puara Leaky Integrator processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,16 @@ avnd_score_plugin_add(
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
   SOURCES
+    Puara/LeakyIntegratorAvnd.hpp
+    Puara/LeakyIntegratorAvnd.cpp
+  TARGET puara_leaky_integrator 
+  MAIN_CLASS LeakyIntegratorAvnd
+  NAMESPACE puara_gestures::objects
+)
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
     Puara/BioDataHeart.hpp
     Puara/BioDataHeart.cpp
     3rdparty/BioData/src/Heart.cpp

--- a/Puara/LeakyIntegratorAvnd.cpp
+++ b/Puara/LeakyIntegratorAvnd.cpp
@@ -1,0 +1,21 @@
+#include "LeakyIntegratorAvnd.hpp"
+
+namespace puara_gestures::objects
+{
+
+void LeakyIntegratorAvnd::operator()(halp::tick t)
+{
+  const float current_input_signal = inputs.input_value.value;
+  const float current_leak_factor  = inputs.leak_param.value;
+
+  double output_val = impl.integrate(
+      static_cast<double>(current_input_signal),
+      static_cast<double>(current_leak_factor)
+      );
+
+
+  outputs.output_value.value = static_cast<float>(output_val);
+
+}
+
+}

--- a/Puara/LeakyIntegratorAvnd.hpp
+++ b/Puara/LeakyIntegratorAvnd.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <halp/audio.hpp>
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+#include <puara/utils/leakyintegrator.h>
+
+
+namespace puara_gestures::objects
+{
+
+class LeakyIntegratorAvnd
+{
+public:
+  halp_meta(name, "Leaky Integrator")
+  halp_meta(category, "Utilities/Puara")
+  halp_meta(c_name, "puara_leaky_integrator_avnd")
+  halp_meta(uuid, "ed55a080-b821-4977-89b6-4697cb8178e7")
+
+  struct ins
+  {
+    halp::val_port<"Input", float> input_value;
+    // Leak factor (0.0 = full leak this step, 1.0 = no leak this step)
+    halp::knob_f32<"Leak Factor", halp::range{0.0, 1.0, 0.5}> leak_param;
+  } inputs;
+
+  struct
+  {
+    halp::val_port<"Output", float> output_value;
+  } outputs;
+
+  using tick = halp::tick;
+  void operator()(halp::tick t);
+  puara_gestures::utils::LeakyIntegrator impl{0.0, 0.0, 0.5, 0, 0};
+
+  LeakyIntegratorAvnd() = default;
+};
+
+}


### PR DESCRIPTION
Implements the Puara Leaky Integrator as an Avendish processor. - Takes a float input signal and a leak factor (0.0-1.0) as input. - Outputs the integrated float value. - Includes necessary CMake updates for plugin registration.