### PR TITLE
feat(analysis): Add Power Band processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
+include(FetchContent)
+FetchContent_Declare(xtl GIT_REPOSITORY https://github.com/xtensor-stack/xtl.git GIT_TAG 0.7.5)
+FetchContent_Declare(xsimd GIT_REPOSITORY https://github.com/xtensor-stack/xsimd.git GIT_TAG 9.0.1)
+FetchContent_Declare(xtensor GIT_REPOSITORY https://github.com/xtensor-stack/xtensor.git GIT_TAG 0.24.6)
+FetchContent_MakeAvailable(xtl xsimd xtensor)
+
 if(NOT TARGET score_lib_base)
   include(ScoreExternalAddon)
 endif()
@@ -62,7 +68,7 @@ target_include_directories(score_addon_puara
   3rdparty/puara-gestures/include/
   3rdparty/puara-gestures/3rdparty/
 )
-target_link_libraries(score_addon_puara PUBLIC BioData)
+target_link_libraries(score_addon_puara PUBLIC BioData xtensor)
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
@@ -93,6 +99,17 @@ avnd_score_plugin_add(
   MAIN_CLASS BioData_Heart
   NAMESPACE puara_gestures::objects
 )
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/PowerBandAvnd.hpp
+    Puara/PowerBandAvnd.cpp
+  TARGET puara_powerband
+  MAIN_CLASS PowerBandAvnd
+  NAMESPACE puara_gestures::objects
+)
+
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ target_include_directories(score_addon_puara
   3rdparty/puara-gestures/include/
   3rdparty/puara-gestures/3rdparty/
 )
-target_link_libraries(score_addon_puara PUBLIC BioData xtensor)
+target_link_libraries(score_addon_puara PUBLIC BioData)
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,6 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 include(FetchContent)
-FetchContent_Declare(xtl GIT_REPOSITORY https://github.com/xtensor-stack/xtl.git GIT_TAG 0.7.5)
-FetchContent_Declare(xsimd GIT_REPOSITORY https://github.com/xtensor-stack/xsimd.git GIT_TAG 9.0.1)
-FetchContent_Declare(xtensor GIT_REPOSITORY https://github.com/xtensor-stack/xtensor.git GIT_TAG 0.24.6)
-FetchContent_MakeAvailable(xtl xsimd xtensor)
 
 if(NOT TARGET score_lib_base)
   include(ScoreExternalAddon)

--- a/Puara/PowerBandAvnd.cpp
+++ b/Puara/PowerBandAvnd.cpp
@@ -1,0 +1,63 @@
+#include "PowerBandAvnd.hpp"
+
+#include <xtensor/containers/xadapt.hpp>
+#include <xtensor/views/xview.hpp>
+#include <vector>
+
+namespace puara_gestures::objects
+{
+
+void PowerBandAvnd::operator()()
+{
+  const auto& psd_vec = inputs.psd.value;
+  const auto& freq_vec = inputs.frequencies.value;
+
+  if (psd_vec.empty() || freq_vec.empty() || psd_vec.size() != freq_vec.size())
+  {
+    outputs.power.value = 0.0;
+    return;
+  }
+
+  const double f_min = inputs.f_min;
+  const double f_max = inputs.f_max;
+  const auto power_type = inputs.power_type.value;
+
+  auto psd_arr = xt::adapt(psd_vec);
+  auto freq_arr = xt::adapt(freq_vec);
+
+  std::vector<size_t> valid_indices;
+  for (size_t i = 0; i < freq_arr.size(); ++i)
+  {
+    if (freq_arr(i) >= f_min && freq_arr(i) <= f_max)
+    {
+      valid_indices.push_back(i);
+    }
+  }
+
+  if (valid_indices.empty())
+  {
+    outputs.power.value = 0.0;
+    return;
+  }
+
+  auto selected_psd = xt::view(psd_arr, xt::keep(valid_indices));
+
+  double band_power = xt::sum(selected_psd)();
+
+  if (power_type == PowerType::Relative)
+  {
+    double total_power = xt::sum(psd_arr)();
+    if (total_power > 0)
+    {
+      band_power /= total_power;
+    }
+    else
+    {
+      band_power = 0.0;
+    }
+  }
+
+  outputs.power.value = band_power;
+}
+
+}

--- a/Puara/PowerBandAvnd.hpp
+++ b/Puara/PowerBandAvnd.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+#include <vector>
+
+namespace puara_gestures::objects
+{
+
+class PowerBandAvnd
+{
+public:
+  halp_meta(name, "Power Band")
+  halp_meta(category, "Analysis/Puara")
+  halp_meta(c_name, "puara_powerband_avnd")
+  halp_meta(description, "Computes the power within a specific frequency band from a PSD.")
+  halp_meta(manual_url, "https://github.com/dav0dea/goofi-pipe")
+  halp_meta(uuid, "defc59ec-4067-4430-aef3-e95cfd2b870f")
+
+  enum class PowerType { Absolute, Relative };
+
+  struct ins
+  {
+    // The Power Spectral Density values
+    halp::val_port<"PSD", std::vector<double>> psd;
+    // The frequency value corresponding to each PSD point
+    halp::val_port<"Frequencies", std::vector<double>> frequencies;
+
+    // --- Parameters ---
+    halp::knob_f32<"Min Frequency (Hz)", halp::range{0.01, 9999.0, 1.0}> f_min;
+    halp::knob_f32<"Max Frequency (Hz)", halp::range{1.0, 10000.0, 60.0}> f_max;
+    halp::enum_t<PowerType, "Power Type"> power_type{PowerType::Absolute};
+  } inputs;
+
+  struct outs
+  {
+    // The final computed power is a single value
+    halp::val_port<"Power", double> power;
+  } outputs;
+
+  void operator()();
+};
+
+}

--- a/Puara/statistics_algorithms.hpp
+++ b/Puara/statistics_algorithms.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/core/xmath.hpp>
+#include <boost/math/distributions/students_t.hpp>
+#include <utility>
+
+namespace puara_gestures::algorithms
+{
+inline std::pair<double, double> calculate_pearson(const xt::xarray<double>& x, const xt::xarray<double>& y)
+{
+  const size_t n = x.size();
+  if (n < 3) {
+    
+    return {0.0, 1.0};
+  }
+
+  
+  const double mean_x = xt::mean(x)();
+  const double mean_y = xt::mean(y)();
+
+  const double cov_xy = xt::mean((x - mean_x) * (y - mean_y))();
+  const double stddev_x = xt::stddev(x)();
+  const double stddev_y = xt::stddev(y)();
+
+  if (stddev_x == 0.0 || stddev_y == 0.0) {
+    
+    return {0.0, 1.0};
+  }
+  const double r = cov_xy / (stddev_x * stddev_y);
+
+  const double r_clamped = std::max(-1.0, std::min(1.0, r));
+
+  
+  if (std::abs(r_clamped) == 1.0) {
+    return {r_clamped, 0.0};
+  }
+  const double t_stat = r_clamped * std::sqrt((n - 2.0) / (1.0 - r_clamped * r_clamped));
+
+  boost::math::students_t dist(n - 2.0);
+  double p = boost::math::cdf(boost::math::complement(dist, std::abs(t_stat))) * 2.0;
+
+  return {r, p};
+}
+
+}
+
+#include <xtensor/views/xview.hpp>
+#include <vector>
+
+namespace puara_gestures::algorithms
+{
+enum class PowerBandType { Absolute, Relative };
+
+inline double calculate_power_in_band(
+    const xt::xarray<double>& psd,
+    const xt::xarray<double>& freqs,
+    double f_min,
+    double f_max,
+    PowerBandType power_type)
+{
+  std::vector<size_t> valid_indices;
+  for (size_t i = 0; i < freqs.size(); ++i)
+  {
+    if (freqs(i) >= f_min && freqs(i) <= f_max)
+    {
+      valid_indices.push_back(i);
+    }
+  }
+
+  if (valid_indices.empty())
+  {
+    return 0.0;
+  }
+
+  auto selected_psd = xt::view(psd, xt::keep(valid_indices));
+
+  double band_power = xt::sum(selected_psd)();
+
+  if (power_type == PowerBandType::Relative)
+  {
+    double total_power = xt::sum(psd)();
+    return (total_power > 0) ? (band_power / total_power) : 0.0;
+  }
+
+  return band_power;
+}
+
+}


### PR DESCRIPTION

Implements the \`Power Band\` processor, ported from the \`goofi-pipe\` analysis nodes. This processor calculates the total power within a specified frequency band from a Power Spectral Density (PSD) input.

### Functionality

- Accepts a PSD array and a corresponding frequencies array as input.
- Allows user-defined frequency bands via \`f_min\` and \`f_max\` parameters.
- Supports two modes:
  - Absolute power: sum of PSD values within the frequency band.
  - Relative power: ratio of band power to total power.

### Implementation Notes

- Introduces \`xtensor\` as a dependency for efficient, NumPy-like array operations in C++.
- Adds a reusable helper file: \`statistics_algorithms.hpp\` that contains the core power band computation logic."
