### PR TITLE
feat(analysis): Add Power Band EEG processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,7 +183,15 @@ avnd_score_plugin_add(
   MAIN_CLASS Shake
   NAMESPACE puara_gestures::objects
 )
-
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/PowerBandEEGAvnd.hpp
+    Puara/PowerBandEEGAvnd.cpp
+  TARGET puara_powerband_eeg
+  MAIN_CLASS PowerBandEEGAvnd
+  NAMESPACE puara_gestures::objects
+)
 avnd_score_plugin_finalize(
   BASE_TARGET score_addon_puara
   PLUGIN_VERSION 1

--- a/Puara/PowerBandEEGAvnd.cpp
+++ b/Puara/PowerBandEEGAvnd.cpp
@@ -1,0 +1,45 @@
+#include "PowerBandEEGAvnd.hpp"
+
+#include "statistics_algorithms.hpp" // Where our helper function lives
+
+#include <xtensor.hpp>
+namespace puara_gestures::objects
+{
+
+void PowerBandEEGAvnd::operator()()
+{
+  const auto& psd_vec = inputs.psd.value;
+  const auto& freq_vec = inputs.frequencies.value;
+
+  if(psd_vec.empty() || freq_vec.empty() || psd_vec.size() != freq_vec.size())
+  {
+
+    outputs.delta.value = 0.0;
+    outputs.theta.value = 0.0;
+    outputs.alpha.value = 0.0;
+    outputs.low_beta.value = 0.0;
+    outputs.high_beta.value = 0.0;
+    outputs.gamma.value = 0.0;
+    return;
+  }
+
+  const auto power_type = inputs.power_type.value;
+
+  auto psd_arr = xt::adapt(psd_vec);
+  auto freq_arr = xt::adapt(freq_vec);
+
+  outputs.delta.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 1.0, 3.0, power_type);
+  outputs.theta.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 3.0, 7.0, power_type);
+  outputs.alpha.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 7.0, 12.0, power_type);
+  outputs.low_beta.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 12.0, 20.0, power_type);
+  outputs.high_beta.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 20.0, 30.0, power_type);
+  outputs.gamma.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 30.0, 50.0, power_type);
+}
+
+}

--- a/Puara/PowerBandEEGAvnd.hpp
+++ b/Puara/PowerBandEEGAvnd.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "statistics_algorithms.hpp"
+
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+
+#include <vector>
+
+namespace puara_gestures::objects
+{
+
+class PowerBandEEGAvnd
+{
+public:
+  halp_meta(name, "Power Band EEG")
+  halp_meta(category, "Analysis/Puara")
+  halp_meta(c_name, "puara_powerbandeeg_avnd")
+  halp_meta(
+      description,
+      "Computes power for standard EEG frequency bands (Delta, Theta, Alpha, etc.).")
+  halp_meta(manual_url, "https://github.com/dav0dea/goofi-pipe")
+  halp_meta(uuid, "d9a95cf8-b952-412e-882c-f5ebd96ace36")
+
+  struct ins
+  {
+    halp::val_port<"PSD", std::vector<double>> psd;
+    halp::val_port<"Frequencies", std::vector<double>> frequencies;
+    halp::enum_t<algorithms::PowerBandType, "Power Type"> power_type{
+        algorithms::PowerBandType::Absolute};
+  } inputs;
+
+  struct outs
+  {
+    halp::val_port<"Delta (1-3 Hz)", double> delta;
+    halp::val_port<"Theta (3-7 Hz)", double> theta;
+    halp::val_port<"Alpha (7-12 Hz)", double> alpha;
+    halp::val_port<"Low Beta (12-20 Hz)", double> low_beta;
+    halp::val_port<"High Beta (20-30 Hz)", double> high_beta;
+    halp::val_port<"Gamma (30-50 Hz)", double> gamma;
+  } outputs;
+
+  void operator()();
+};
+
+}

--- a/Puara/statistics_algorithms.hpp
+++ b/Puara/statistics_algorithms.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <boost/math/distributions/students_t.hpp>
+
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/core/xmath.hpp>
+
+#include <utility>
+
+namespace puara_gestures::algorithms
+{
+
+inline std::pair<double, double>
+calculate_pearson(const xt::xarray<double>& x, const xt::xarray<double>& y)
+{
+  const size_t n = x.size();
+  if(n < 3)
+  {
+    return {0.0, 1.0};
+  }
+
+  const double mean_x = xt::mean(x)();
+  const double mean_y = xt::mean(y)();
+
+  const double cov_xy = xt::mean((x - mean_x) * (y - mean_y))();
+  const double stddev_x = xt::stddev(x)();
+  const double stddev_y = xt::stddev(y)();
+
+  if(stddev_x == 0.0 || stddev_y == 0.0)
+  {
+
+    return {0.0, 1.0};
+  }
+  const double r = cov_xy / (stddev_x * stddev_y);
+
+  const double r_clamped = std::max(-1.0, std::min(1.0, r));
+
+  if(std::abs(r_clamped) == 1.0)
+  {
+
+    return {r_clamped, 0.0};
+  }
+  const double t_stat = r_clamped * std::sqrt((n - 2.0) / (1.0 - r_clamped * r_clamped));
+
+  boost::math::students_t dist(n - 2.0);
+  double p = boost::math::cdf(boost::math::complement(dist, std::abs(t_stat))) * 2.0;
+
+  return {r, p};
+}
+
+}
+
+#include <xtensor/views/xview.hpp>
+
+#include <vector>
+
+namespace puara_gestures::algorithms
+{
+
+enum class PowerBandType
+{
+  Absolute,
+  Relative
+};
+
+inline double calculate_power_in_band(
+    const xt::xarray<double>& psd, const xt::xarray<double>& freqs, double f_min,
+    double f_max, PowerBandType power_type)
+{
+
+  std::vector<size_t> valid_indices;
+  for(size_t i = 0; i < freqs.size(); ++i)
+  {
+    if(freqs(i) >= f_min && freqs(i) <= f_max)
+    {
+      valid_indices.push_back(i);
+    }
+  }
+
+  if(valid_indices.empty())
+  {
+    return 0.0;
+  }
+
+  auto selected_psd = xt::view(psd, xt::keep(valid_indices));
+
+  double band_power = xt::sum(selected_psd)();
+
+  if(power_type == PowerBandType::Relative)
+  {
+    double total_power = xt::sum(psd)();
+    return (total_power > 0) ? (band_power / total_power) : 0.0;
+  }
+
+  return band_power;
+}
+
+}


### PR DESCRIPTION
### Summary

Implements the `Power Band EEG` processor. This node is a specialized version of the `PowerBand` processor that computes power for a set of fixed, standard EEG frequency bands (Delta, Theta, Alpha, etc.) simultaneously.

### Functionality

- Takes a PSD array and a corresponding frequencies array as input.
- Outputs the calculated power for each of the 6 standard EEG bands on dedicated output ports.
- Supports both absolute and relative power calculations.

### Implementation Notes

- This processor reuses the `calculate_power_in_band` helper function and dependencies introduced in the `PowerBand` PR.