### PR TITLE
feat(analysis): Add Correlation processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
+include(FetchContent)
+FetchContent_Declare(xtl GIT_REPOSITORY https://github.com/xtensor-stack/xtl.git GIT_TAG 0.7.5)
+FetchContent_Declare(xsimd GIT_REPOSITORY https://github.com/xtensor-stack/xsimd.git GIT_TAG 9.0.1)
+FetchContent_Declare(xtensor GIT_REPOSITORY https://github.com/xtensor-stack/xtensor.git GIT_TAG 0.24.6)
+FetchContent_MakeAvailable(xtl xsimd xtensor)
 if(NOT TARGET score_lib_base)
   include(ScoreExternalAddon)
 endif()
@@ -60,7 +65,7 @@ target_include_directories(score_addon_puara
   3rdparty/puara-gestures/include/
   3rdparty/puara-gestures/3rdparty/
 )
-target_link_libraries(score_addon_puara PUBLIC BioData)
+target_link_libraries(score_addon_puara PUBLIC BioData xtensor)
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
@@ -81,6 +86,17 @@ avnd_score_plugin_add(
   MAIN_CLASS LeakyIntegratorAvnd
   NAMESPACE puara_gestures::objects
 )
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/CorrelationAvnd.hpp
+    Puara/CorrelationAvnd.cpp
+  TARGET puara_correlation_avnd
+  MAIN_CLASS CorrelationAvnd
+  NAMESPACE puara_gestures::objects
+)
+
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara

--- a/Puara/CorrelationAvnd.cpp
+++ b/Puara/CorrelationAvnd.cpp
@@ -1,0 +1,28 @@
+#include "CorrelationAvnd.hpp"
+#include "statistics_algorithms.hpp"
+#include <xtensor/containers/xadapt.hpp>
+
+namespace puara_gestures::objects
+{
+
+void CorrelationAvnd::operator()()
+{
+  const auto& vec1 = inputs.data1.value;
+  const auto& vec2 = inputs.data2.value;
+
+
+  if (vec1.empty() || vec2.empty() || vec1.size() != vec2.size())
+  {
+    outputs.pearson.value = 0.0;
+    outputs.p_value.value = 1.0;
+    return;
+  }
+  auto arr1 = xt::adapt(vec1);
+  auto arr2 = xt::adapt(vec2);
+  auto [r, p] = algorithms::calculate_pearson(arr1, arr2);
+
+  outputs.pearson.value = r;
+  outputs.p_value.value = p;
+}
+
+}

--- a/Puara/CorrelationAvnd.hpp
+++ b/Puara/CorrelationAvnd.hpp
@@ -1,0 +1,36 @@
+
+#pragma once
+
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+#include <vector>
+
+namespace puara_gestures::objects
+{
+
+class CorrelationAvnd
+{
+public:
+  halp_meta(name, "Correlation")
+  halp_meta(category, "Analysis/Puara")
+  halp_meta(c_name, "puara_correlation_avnd")
+  halp_meta(description, "Computes the Pearson correlation and p-value between two data arrays.")
+  halp_meta(manual_url, "https://github.com/dav0dea/goofi-pipe")
+  halp_meta(uuid, "202a5150-0452-403f-930e-7fa18564c863")
+
+  struct
+  {
+    halp::val_port<"Data 1", std::vector<double>> data1;
+    halp::val_port<"Data 2", std::vector<double>> data2;
+  } inputs;
+
+  struct
+  {
+    halp::val_port<"Pearson (r)", double> pearson;
+    halp::val_port<"p-value", double> p_value;
+  } outputs;
+
+  void operator()();
+};
+
+}

--- a/Puara/statistics_algorithms.hpp
+++ b/Puara/statistics_algorithms.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <xtensor/containers/xarray.hpp>
+#include <xtensor/core/xmath.hpp>
+#include <boost/math/distributions/students_t.hpp>
+#include <utility>
+
+namespace puara_gestures::algorithms
+{
+
+// Calculates the Pearson correlation coefficient 'r' and the two-tailed p-value.
+inline std::pair<double, double> calculate_pearson(const xt::xarray<double>& x, const xt::xarray<double>& y)
+{
+  const size_t n = x.size();
+  if (n < 3) {
+    // Not enough data to compute correlation or p-value meaningfully
+    return {0.0, 1.0};
+  }
+
+  // Calculate means
+  const double mean_x = xt::mean(x)();
+  const double mean_y = xt::mean(y)();
+
+  // Calculate covariance and standard deviations
+  const double cov_xy = xt::mean((x - mean_x) * (y - mean_y))();
+  const double stddev_x = xt::stddev(x)();
+  const double stddev_y = xt::stddev(y)();
+
+  // Calculate Pearson's r
+  if (stddev_x == 0.0 || stddev_y == 0.0) {
+    // If one variable is constant, correlation is not defined.
+    return {0.0, 1.0};
+  }
+  const double r = cov_xy / (stddev_x * stddev_y);
+
+  // Clamp r to avoid domain errors in p-value calculation
+  const double r_clamped = std::max(-1.0, std::min(1.0, r));
+
+  // Calculate p-value from the t-statistic
+  if (std::abs(r_clamped) == 1.0) {
+    // Perfect correlation
+    return {r_clamped, 0.0};
+  }
+  const double t_stat = r_clamped * std::sqrt((n - 2.0) / (1.0 - r_clamped * r_clamped));
+
+  boost::math::students_t dist(n - 2.0);
+  double p = boost::math::cdf(boost::math::complement(dist, std::abs(t_stat))) * 2.0;
+
+  return {r, p};
+}
+
+}
+// Add this to your statistics_algorithms.hpp file
+
+#include <xtensor/views/xview.hpp>
+#include <vector>
+
+namespace puara_gestures::algorithms
+{
+// (The calculate_pearson function is already here)
+
+// Helper enum to match the one in our processors
+enum class PowerBandType { Absolute, Relative };
+
+// Refactored function to calculate power in a specific band
+inline double calculate_power_in_band(
+    const xt::xarray<double>& psd,
+    const xt::xarray<double>& freqs,
+    double f_min,
+    double f_max,
+    PowerBandType power_type)
+{
+  // Find indices of frequencies within the desired band
+  std::vector<size_t> valid_indices;
+  for (size_t i = 0; i < freqs.size(); ++i)
+  {
+    if (freqs(i) >= f_min && freqs(i) <= f_max)
+    {
+      valid_indices.push_back(i);
+    }
+  }
+
+  if (valid_indices.empty())
+  {
+    return 0.0;
+  }
+
+  // Create a view of the PSD array using only the valid indices
+  auto selected_psd = xt::view(psd, xt::keep(valid_indices));
+
+  // Compute the power in the band
+  double band_power = xt::sum(selected_psd)();
+
+  // Handle relative power calculation
+  if (power_type == PowerBandType::Relative)
+  {
+    double total_power = xt::sum(psd)();
+    return (total_power > 0) ? (band_power / total_power) : 0.0;
+  }
+
+  return band_power;
+}
+
+}


### PR DESCRIPTION
### Summary

Implements the Correlation processor, which computes the Pearson correlation coefficient (r-value) and the corresponding p-value between two data arrays.

### Implementation Notes

This PR adds Boost (Math) as a new dependency to calculate the p-value from a t-distribution. The core logic is contained in the statistics_algorithms.hpp helper file.