### PR TITLE
feat(analysis): Add Compass processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
+include(FetchContent)
+FetchContent_Declare(xtl GIT_REPOSITORY https://github.com/xtensor-stack/xtl.git GIT_TAG 0.7.5)
+FetchContent_Declare(xsimd GIT_REPOSITORY https://github.com/xtensor-stack/xsimd.git GIT_TAG 9.0.1)
+FetchContent_Declare(xtensor GIT_REPOSITORY https://github.com/xtensor-stack/xtensor.git GIT_TAG 0.24.6)
+FetchContent_MakeAvailable(xtl xsimd xtensor)
+
 if(NOT TARGET score_lib_base)
   include(ScoreExternalAddon)
 endif()
@@ -60,7 +66,7 @@ target_include_directories(score_addon_puara
   3rdparty/puara-gestures/include/
   3rdparty/puara-gestures/3rdparty/
 )
-target_link_libraries(score_addon_puara PUBLIC BioData)
+target_link_libraries(score_addon_puara PUBLIC BioData xtensor)
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
@@ -81,6 +87,21 @@ avnd_score_plugin_add(
   MAIN_CLASS LeakyIntegratorAvnd
   NAMESPACE puara_gestures::objects
 )
+
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/CompassAvnd.hpp
+    Puara/CompassAvnd.cpp
+  TARGET puara_compass_avnd
+  MAIN_CLASS CompassAvnd
+  NAMESPACE puara_gestures::objects
+)
+
+
+
+
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara

--- a/Puara/CompassAvnd.cpp
+++ b/Puara/CompassAvnd.cpp
@@ -1,0 +1,54 @@
+#include "CompassAvnd.hpp"
+
+#include <xtensor/containers/xadapt.hpp>
+#include <xtensor/containers/xarray.hpp>
+
+#include <cmath>
+
+namespace puara_gestures::objects
+{
+
+void CompassAvnd::operator()()
+{
+  const auto& pole1_vec = inputs.pole1.value;
+  const auto& pole2_vec = inputs.pole2.value;
+
+  outputs.angles.value.clear();
+
+  if(pole1_vec.empty() || pole2_vec.empty() || pole1_vec.size() != pole2_vec.size())
+  {
+
+    return;
+  }
+
+  auto pole1_arr = xt::adapt(pole1_vec);
+  auto pole2_arr = xt::adapt(pole2_vec);
+
+  xt::xarray<double> vector_diff = pole2_arr - pole1_arr;
+
+  if(vector_diff.size() < 2)
+  {
+
+    return;
+  }
+
+  for(size_t i = 0; i < vector_diff.size() - 1; ++i)
+  {
+    const double x = vector_diff(i);
+    const double y = vector_diff(i + 1);
+
+    const double angle_rad = std::atan2(y, x);
+
+    const double angle_deg = angle_rad * 180.0 / ossia::pi;
+
+    double normalized_deg = std::fmod(angle_deg, 360.0);
+    if(normalized_deg < 0)
+    {
+      normalized_deg += 360.0;
+    }
+
+    outputs.angles.value.push_back(normalized_deg);
+  }
+}
+
+}

--- a/Puara/CompassAvnd.hpp
+++ b/Puara/CompassAvnd.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+
+#include <vector>
+
+namespace puara_gestures::objects
+{
+
+class CompassAvnd
+{
+public:
+  halp_meta(name, "Compass")
+  halp_meta(category, "Analysis/Puara")
+  halp_meta(c_name, "puara_compass_avnd")
+  halp_meta(description, "Calculates angles from two N-dimensional polar arrays.")
+  halp_meta(manual_url, "https://github.com/dav0dea/goofi-pipe")
+  halp_meta(uuid, "b0a377c7-0c7c-4525-be9a-2c3d0e67d41c")
+
+  struct ins
+  {
+    halp::val_port<"Pole 1", std::vector<double>> pole1;
+    halp::val_port<"Pole 2", std::vector<double>> pole2;
+  } inputs;
+
+  struct outs
+  {
+    halp::val_port<"Angles (degrees)", std::vector<double>> angles;
+  } outputs;
+
+  void operator()();
+};
+
+}


### PR DESCRIPTION
### Summary

Implements the **Compass** processor, which calculates angles (in degrees) between two N-dimensional polar coordinate arrays.

### Implementation Notes

- Takes two input vectors: `Pole 1` and `Pole 2`.
- Computes the angle between each corresponding pair of vectors.
- Outputs the angle values as a vector in degrees.
- Logic is encapsulated in `CompassAvnd.hpp` and `CompassAvnd.cpp`.
- Built using HALP metadata and control ports for seamless integration.