### PR TITLE
feat(analysis): Add ERP processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,14 +86,16 @@ avnd_score_plugin_add(
   NAMESPACE puara_gestures::objects
 )
 
-
-avnd_score_plugin_add(BASE_TARGET score_addon_puara
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/VAMPAvnd.hpp
-    Puara/VAMPAvnd.cpp
-  TARGET puara_vamp
-  MAIN_CLASS VAMPAvnd
-  NAMESPACE puara_gestures::objects)
+    Puara/ERPAvnd.hpp
+    Puara/ERPAvnd.cpp
+  TARGET puara_erp_avnd
+  MAIN_CLASS ERPAvnd
+  NAMESPACE puara_gestures::objects
+)
+
 
 
 avnd_score_plugin_add(
@@ -105,17 +107,6 @@ avnd_score_plugin_add(
   MAIN_CLASS BioData_Heart
   NAMESPACE puara_gestures::objects
 )
-
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/PowerBandAvnd.hpp
-    Puara/PowerBandAvnd.cpp
-  TARGET puara_powerband
-  MAIN_CLASS PowerBandAvnd
-  NAMESPACE puara_gestures::objects
-)
-
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
@@ -146,16 +137,6 @@ avnd_score_plugin_add(
     3rdparty/extras/PeakDetector.h
   TARGET puara_peak_detection
   MAIN_CLASS PeakDetection
-  NAMESPACE puara_gestures::objects
-)
-
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/AvalanchesAvnd.hpp
-    Puara/AvalanchesAvnd.cpp
-  TARGET avalanches_avnd
-  MAIN_CLASS AvalanchesAvnd
   NAMESPACE puara_gestures::objects
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,18 +97,6 @@ avnd_score_plugin_add(
   NAMESPACE puara_gestures::objects
 )
 
-=======
-    Puara/WalkerAvnd.hpp
-    Puara/WalkerAvnd.cpp
-  TARGET puara_walker_avnd
-  MAIN_CLASS WalkerAvnd
-  NAMESPACE puara_gestures::objects
-)
-
-
-
-
-
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
   SOURCES

--- a/Puara/ERPAvnd.cpp
+++ b/Puara/ERPAvnd.cpp
@@ -1,0 +1,80 @@
+#include "ERPAvnd.hpp"
+
+#include <xtensor/containers/xadapt.hpp>
+#include <xtensor/core/xmath.hpp>
+#include <xtensor/views/xview.hpp>
+
+namespace puara_gestures::objects
+{
+
+void ERPAvnd::operator()()
+{
+  if(!inputs.reset.value.has_value())
+  {
+    reset_state();
+  }
+
+  const auto& signal_chunk = inputs.signal.value;
+  if(signal_chunk.empty())
+  {
+    return;
+  }
+  const bool triggered = inputs.trigger.value.has_value();
+  if(triggered)
+  {
+    if(!m_is_collecting || !inputs.delay_retrigger.value)
+    {
+      m_is_collecting = true;
+      m_collected_chunk.clear();
+    }
+  }
+  if(!m_is_collecting)
+  {
+    return;
+  }
+  m_collected_chunk.insert(
+      m_collected_chunk.end(), signal_chunk.begin(), signal_chunk.end());
+
+  const int target_samples = static_cast<int>(inputs.duration.value * m_sampling_rate);
+  if(m_collected_chunk.size() < target_samples)
+  {
+    return;
+  }
+  auto collected_arr = xt::adapt(m_collected_chunk);
+  auto erp_segment = xt::view(collected_arr, xt::range(0, target_samples));
+
+  if(inputs.baseline.value == BaselineCorrection::Mean)
+  {
+    erp_segment = erp_segment - xt::mean(erp_segment)();
+  }
+
+  if(m_erp_count == 0)
+  {
+    m_erp_sum = erp_segment;
+  }
+  else if(m_erp_sum.size() != erp_segment.size())
+  {
+    reset_state();
+    m_erp_sum = erp_segment;
+  }
+  else
+  {
+    m_erp_sum += erp_segment;
+  }
+  m_erp_count++;
+  xt::xarray<double> final_erp = m_erp_sum / m_erp_count;
+  outputs.erp.value.assign(final_erp.begin(), final_erp.end());
+  m_is_collecting = false;
+  m_collected_chunk.clear();
+}
+
+void ERPAvnd::reset_state()
+{
+  m_erp_count = 0;
+  m_is_collecting = false;
+  m_collected_chunk.clear();
+  m_erp_sum.resize({0});
+  outputs.erp.value.clear();
+}
+
+}

--- a/Puara/ERPAvnd.hpp
+++ b/Puara/ERPAvnd.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <halp/audio.hpp>
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+#include <xtensor/containers/xarray.hpp>
+
+#include <optional>
+#include <vector>
+
+namespace puara_gestures::objects
+{
+
+class ERPAvnd
+{
+public:
+  halp_meta(name, "ERP")
+  halp_meta(category, "Analysis/Puara")
+  halp_meta(c_name, "puara_erp_avnd")
+  halp_meta(
+      description,
+      "Computes an Event-Related Potential (ERP) from a signal and triggers.")
+  halp_meta(manual_url, "https://github.com/dav0dea/goofi-pipe")
+  halp_meta(uuid, "4f9c3a03-48df-4c30-ba0e-653989b37843")
+
+  enum class BaselineCorrection
+  {
+    None,
+    Mean
+  };
+
+  struct ins
+  {
+    halp::val_port<"Signal", std::vector<double>> signal;
+    halp::val_port<"Trigger", std::optional<bool>> trigger;
+
+    // --- Parameters ---
+    halp::knob_f32<"Duration (s)", halp::range{0.0, 3.0, 1.0}> duration;
+    halp::enum_t<BaselineCorrection, "Baseline"> baseline{BaselineCorrection::Mean};
+    halp::impulse_button<"Reset"> reset;
+    halp::toggle<"Delay Retrigger"> delay_retrigger{true};
+  } inputs;
+
+  struct outs
+  {
+    halp::val_port<"ERP", std::vector<double>> erp;
+  } outputs;
+
+  void prepare(halp::setup& setup) { m_sampling_rate = setup.rate; }
+  void operator()();
+
+private:
+  void reset_state();
+
+  // --- State Variables ---
+  double m_sampling_rate{1000.0};
+  bool m_is_collecting{false};
+  int m_erp_count{0};
+  std::vector<double> m_collected_chunk;
+  xt::xarray<double> m_erp_sum;
+};
+
+}


### PR DESCRIPTION
### Summary

Implements the **ERP (Event-Related Potential)** processor, which computes averaged signal responses aligned to trigger events — commonly used in neuroscience and time-locked signal analysis.

### Implementation Notes

- Accepts a continuous signal and an optional trigger stream as input.
- Supports baseline correction modes (`None` and `Mean`) and configurable ERP duration.
- Includes options to reset the state and toggle delayed retriggering.
- ERP accumulation and averaging are handled using `xt::xarray` from xtensor.
- Core logic is implemented in `ERPAvnd.hpp` and `ERPAvnd.cpp` with support for sample rate setup via `prepare()`.