### PR TITLE
feat(puara): Add PCAAvnd processor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,17 @@ avnd_score_plugin_add(
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
   SOURCES
+    Puara/WalkerAvnd.hpp
+    Puara/WalkerAvnd.cpp
+  TARGET walker_avnd
+  MAIN_CLASS WalkerAvnd
+  NAMESPACE puara_gestures::objects
+)
+
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
     Puara/BioDataSkinConductance.hpp
     Puara/BioDataSkinConductance.cpp
   TARGET puara_skin_conductance

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
-include(FetchContent)
-
 if(NOT TARGET score_lib_base)
   include(ScoreExternalAddon)
 endif()
@@ -16,9 +14,7 @@ set(PUARA_GESTURES_ENABLE_TESTING OFF)
 set(PUARA_GESTURES_ENABLE_STANDALONE OFF)
 
 add_subdirectory(3rdparty/BioData SYSTEM)
-target_compile_features(BioData PRIVATE cxx_std_23)
 add_subdirectory(3rdparty/extras SYSTEM)
-target_compile_features(extras PRIVATE cxx_std_23)
 
 avnd_score_plugin_init(
   BASE_TARGET score_addon_puara
@@ -57,8 +53,8 @@ target_sources(score_addon_puara
   3rdparty/extras/PeakDetector.cpp
   3rdparty/extras/helpers.h
   3rdparty/extras/helpers.cpp
+  Puara/vamp_algorithms.hpp
 )
-
 target_include_directories(score_addon_puara
   PRIVATE
   3rdparty/puara-gestures/include/
@@ -75,6 +71,25 @@ avnd_score_plugin_add(
   MAIN_CLASS GestureRecognizer
   NAMESPACE puara_gestures::objects
 )
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/PowerBandAvnd.hpp
+    Puara/PowerBandAvnd.cpp
+  TARGET puara_powerband
+  MAIN_CLASS PowerBandAvnd
+  NAMESPACE puara_gestures::objects
+)
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/CorrelationAvnd.hpp
+    Puara/CorrelationAvnd.cpp
+  TARGET puara_correlation_avnd
+  MAIN_CLASS CorrelationAvnd
+  NAMESPACE puara_gestures::objects
+)
+
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
@@ -85,17 +100,6 @@ avnd_score_plugin_add(
   MAIN_CLASS LeakyIntegratorAvnd
   NAMESPACE puara_gestures::objects
 )
-
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/WalkerAvnd.hpp
-    Puara/WalkerAvnd.cpp
-  TARGET puara_walker_avnd
-  MAIN_CLASS WalkerAvnd
-  NAMESPACE puara_gestures::objects
-)
-
 
 
 
@@ -126,6 +130,16 @@ avnd_score_plugin_add(
     Puara/BioDataSkinConductance.cpp
   TARGET puara_skin_conductance
   MAIN_CLASS BioData_Skin_Conductance
+  NAMESPACE puara_gestures::objects
+)
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/VAMPAvnd.hpp
+    Puara/VAMPAvnd.cpp
+  TARGET vamp_avnd
+  MAIN_CLASS VAMPAvnd
   NAMESPACE puara_gestures::objects
 )
 
@@ -181,6 +195,15 @@ avnd_score_plugin_add(
   NAMESPACE puara_gestures::objects
 )
 
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/PCAAvnd.hpp
+    Puara/PCAAvnd.cpp
+  TARGET pca_avnd
+  MAIN_CLASS PCAAvnd
+  NAMESPACE puara_gestures::objects
+)
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,16 +80,6 @@ avnd_score_plugin_add(
   MAIN_CLASS PowerBandAvnd
   NAMESPACE puara_gestures::objects
 )
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/CorrelationAvnd.hpp
-    Puara/CorrelationAvnd.cpp
-  TARGET puara_correlation_avnd
-  MAIN_CLASS CorrelationAvnd
-  NAMESPACE puara_gestures::objects
-)
-
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara

--- a/Puara/PCAAvnd.cpp
+++ b/Puara/PCAAvnd.cpp
@@ -1,0 +1,47 @@
+#include "PCAAvnd.hpp"
+#include <Eigen/Dense>
+
+namespace puara_gestures::objects
+{
+
+void PCAAvnd::operator()()
+{
+  if (!inputs.reset.value.has_value()) {
+    m_is_computed = false;
+    m_principal_components.clear();
+  }
+  if (m_is_computed) {
+    outputs.principal_components.value = m_principal_components;
+    return;
+  }
+  outputs.principal_components.value.clear();
+
+  const auto& input_vec = inputs.data.value;
+  const int n_features = inputs.n_features.value;
+  const int n_components = inputs.n_components.value;
+  if (input_vec.empty() || n_features <= 0 || (input_vec.size() % n_features != 0)) {
+    return;
+  }
+  const int n_samples = input_vec.size() / n_features;
+  if (n_samples < n_features) {
+    return;
+  }
+  using MatrixType = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
+  Eigen::Map<const MatrixType> data_mat(input_vec.data(), n_samples, n_features);
+  Eigen::MatrixXd centered_data = data_mat.rowwise() - data_mat.colwise().mean();
+  Eigen::MatrixXd cov = (centered_data.transpose() * centered_data) / (n_samples - 1.0);
+  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(cov);
+  if (solver.info() != Eigen::Success) {
+    return;
+  }
+  Eigen::MatrixXd eigenvectors = solver.eigenvectors();
+
+  if (eigenvectors.cols() < n_components) {
+    return; // Not enough components found
+  }
+  Eigen::MatrixXd components = eigenvectors.rightCols(n_components).rowwise().reverse();
+  m_principal_components.assign(components.data(), components.data() + components.size());
+  m_is_computed = true;
+  outputs.principal_components.value = m_principal_components;
+}
+}

--- a/Puara/PCAAvnd.cpp
+++ b/Puara/PCAAvnd.cpp
@@ -1,4 +1,5 @@
 #include "PCAAvnd.hpp"
+
 #include <Eigen/Dense>
 
 namespace puara_gestures::objects
@@ -6,11 +7,13 @@ namespace puara_gestures::objects
 
 void PCAAvnd::operator()()
 {
-  if (!inputs.reset.value.has_value()) {
+  if(!inputs.reset.value.has_value())
+  {
     m_is_computed = false;
     m_principal_components.clear();
   }
-  if (m_is_computed) {
+  if(m_is_computed)
+  {
     outputs.principal_components.value = m_principal_components;
     return;
   }
@@ -19,29 +22,52 @@ void PCAAvnd::operator()()
   const auto& input_vec = inputs.data.value;
   const int n_features = inputs.n_features.value;
   const int n_components = inputs.n_components.value;
-  if (input_vec.empty() || n_features <= 0 || (input_vec.size() % n_features != 0)) {
+  if(input_vec.empty() || n_features <= 0 || (input_vec.size() % n_features != 0))
+  {
     return;
   }
   const int n_samples = input_vec.size() / n_features;
-  if (n_samples < n_features) {
+  if(n_samples < n_features)
+  {
     return;
   }
-  using MatrixType = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
-  Eigen::Map<const MatrixType> data_mat(input_vec.data(), n_samples, n_features);
-  Eigen::MatrixXd centered_data = data_mat.rowwise() - data_mat.colwise().mean();
-  Eigen::MatrixXd cov = (centered_data.transpose() * centered_data) / (n_samples - 1.0);
-  Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> solver(cov);
-  if (solver.info() != Eigen::Success) {
-    return;
+  // Resizing matrices only if dimensions changed (avoiding unnecessary allocations)-- change
+  if(m_cached_n_samples != n_samples || m_cached_n_features != n_features)
+  {
+    m_data_matrix.resize(n_samples, n_features);
+    m_centered_data.resize(n_samples, n_features);
+    m_covariance.resize(n_features, n_features);
+    m_components.resize(n_features, n_components);
+    m_cached_n_samples = n_samples;
+    m_cached_n_features = n_features;
   }
-  Eigen::MatrixXd eigenvectors = solver.eigenvectors();
 
-  if (eigenvectors.cols() < n_components) {
+  // Mapping the  input data to matrix (no copy, just viewing)
+  Eigen::Map<
+      const Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>>
+      data_view(input_vec.data(), n_samples, n_features);
+  m_data_matrix = data_view;
+  m_centered_data = m_data_matrix.rowwise() - m_data_matrix.colwise().mean();
+  m_covariance.noalias()
+      = (m_centered_data.transpose() * m_centered_data) / (n_samples - 1.0);
+  m_eigen_solver.compute(m_covariance);
+  if(m_eigen_solver.info() != Eigen::Success)
+  {
+    return;
+  }
+
+  const auto& eigenvectors = m_eigen_solver.eigenvectors();
+  if(eigenvectors.cols() < n_components)
+  {
     return; // Not enough components found
   }
-  Eigen::MatrixXd components = eigenvectors.rightCols(n_components).rowwise().reverse();
-  m_principal_components.assign(components.data(), components.data() + components.size());
+
+  // Extracting components and reversing (reuse m_components matrix)
+  m_components = eigenvectors.rightCols(n_components).rowwise().reverse();
+  m_principal_components.assign(
+      m_components.data(), m_components.data() + m_components.size());
   m_is_computed = true;
   outputs.principal_components.value = m_principal_components;
 }
+
 }

--- a/Puara/PCAAvnd.hpp
+++ b/Puara/PCAAvnd.hpp
@@ -2,7 +2,10 @@
 
 #include <halp/controls.hpp>
 #include <halp/meta.hpp>
+
 #include <vector>
+
+#include <Eigen/Dense>
 
 namespace puara_gestures::objects
 {
@@ -34,6 +37,14 @@ public:
 private:
   std::vector<double> m_principal_components;
   bool m_is_computed{false};
+
+  mutable Eigen::MatrixXd m_data_matrix;
+  mutable Eigen::MatrixXd m_centered_data;
+  mutable Eigen::MatrixXd m_covariance;
+  mutable Eigen::MatrixXd m_components;
+  mutable Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> m_eigen_solver;
+  mutable int m_cached_n_samples{0};
+  mutable int m_cached_n_features{0};
 };
 
 }

--- a/Puara/PCAAvnd.hpp
+++ b/Puara/PCAAvnd.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+#include <vector>
+
+namespace puara_gestures::objects
+{
+
+class PCAAvnd
+{
+public:
+  halp_meta(name, "PCA")
+  halp_meta(category, "ML/Puara")
+  halp_meta(c_name, "puara_pca_avnd")
+  halp_meta(description, "Performs Principal Component Analysis on a dataset.")
+  halp_meta(uuid, "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d")
+
+  struct ins
+  {
+    halp::val_port<"Data", std::vector<double>> data;
+    halp::knob_i32<"Num Features", halp::range{1, 128, 2}> n_features;
+    halp::knob_i32<"Num Components", halp::range{1, 10, 2}> n_components;
+    halp::impulse_button<"Reset"> reset;
+  } inputs;
+
+  struct outs
+  {
+    halp::val_port<"Principal Components", std::vector<double>> principal_components;
+  } outputs;
+
+  void operator()();
+
+private:
+  std::vector<double> m_principal_components;
+  bool m_is_computed{false};
+};
+
+}


### PR DESCRIPTION
This processor performs Principal Component Analysis (PCA), a powerful and widely used technique for dimensionality reduction. It analyzes a dataset to find the principal axes of variance—the directions in which the data is most spread out. The processor outputs the vectors corresponding to these principal components.
By projecting the original data onto the first few principal components, one can reduce the dimensionality of the data while retaining the most important information. This is extremely useful for data visualization, feature engineering for other machine learning tasks, and signal denoising.


