### PR TITLE
Powerbandeeg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ target_sources(score_addon_puara
   3rdparty/extras/helpers.h
   3rdparty/extras/helpers.cpp
   Puara/vamp_algorithms.hpp
+  Puara/statistics_algorithms.hpp
 )
 target_include_directories(score_addon_puara
   PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,7 +222,6 @@ avnd_score_plugin_add(
   MAIN_CLASS Jab3D_Avnd
   NAMESPACE puara_gestures::objects
 )
-
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
   SOURCES
@@ -240,6 +239,15 @@ avnd_score_plugin_add(
     Puara/PCAAvnd.cpp
   TARGET pca_avnd
   MAIN_CLASS PCAAvnd
+  NAMESPACE puara_gestures::objects
+)
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/PowerBandEEGAvnd.hpp
+    Puara/PowerBandEEGAvnd.cpp
+  TARGET puara_powerband_eeg
+  MAIN_CLASS PowerBandEEGAvnd
   NAMESPACE puara_gestures::objects
 )
 

--- a/Puara/PowerBandEEGAvnd.cpp
+++ b/Puara/PowerBandEEGAvnd.cpp
@@ -1,0 +1,45 @@
+#include "PowerBandEEGAvnd.hpp"
+
+#include "statistics_algorithms.hpp" // Where our helper function lives
+
+#include <xtensor/containers/xadapt.hpp>
+namespace puara_gestures::objects
+{
+
+void PowerBandEEGAvnd::operator()()
+{
+  const auto& psd_vec = inputs.psd.value;
+  const auto& freq_vec = inputs.frequencies.value;
+
+  if(psd_vec.empty() || freq_vec.empty() || psd_vec.size() != freq_vec.size())
+  {
+
+    outputs.delta.value = 0.0;
+    outputs.theta.value = 0.0;
+    outputs.alpha.value = 0.0;
+    outputs.low_beta.value = 0.0;
+    outputs.high_beta.value = 0.0;
+    outputs.gamma.value = 0.0;
+    return;
+  }
+
+  const auto power_type = inputs.power_type.value;
+
+  auto psd_arr = xt::adapt(psd_vec);
+  auto freq_arr = xt::adapt(freq_vec);
+
+  outputs.delta.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 1.0, 3.0, power_type);
+  outputs.theta.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 3.0, 7.0, power_type);
+  outputs.alpha.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 7.0, 12.0, power_type);
+  outputs.low_beta.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 12.0, 20.0, power_type);
+  outputs.high_beta.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 20.0, 30.0, power_type);
+  outputs.gamma.value
+      = algorithms::calculate_power_in_band(psd_arr, freq_arr, 30.0, 50.0, power_type);
+}
+
+}

--- a/Puara/PowerBandEEGAvnd.hpp
+++ b/Puara/PowerBandEEGAvnd.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "statistics_algorithms.hpp"
+
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+
+#include <vector>
+
+namespace puara_gestures::objects
+{
+
+class PowerBandEEGAvnd
+{
+public:
+  halp_meta(name, "Power Band EEG")
+  halp_meta(category, "Analysis/Puara")
+  halp_meta(c_name, "puara_powerbandeeg_avnd")
+  halp_meta(
+      description,
+      "Computes power for standard EEG frequency bands (Delta, Theta, Alpha, etc.).")
+  halp_meta(manual_url, "https://github.com/dav0dea/goofi-pipe")
+  halp_meta(uuid, "d9a95cf8-b952-412e-882c-f5ebd96ace36")
+
+  struct ins
+  {
+    halp::val_port<"PSD", std::vector<double>> psd;
+    halp::val_port<"Frequencies", std::vector<double>> frequencies;
+    halp::enum_t<algorithms::PowerBandType, "Power Type"> power_type{
+        algorithms::PowerBandType::Absolute};
+  } inputs;
+
+  struct outs
+  {
+    halp::val_port<"Delta (1-3 Hz)", double> delta;
+    halp::val_port<"Theta (3-7 Hz)", double> theta;
+    halp::val_port<"Alpha (7-12 Hz)", double> alpha;
+    halp::val_port<"Low Beta (12-20 Hz)", double> low_beta;
+    halp::val_port<"High Beta (20-30 Hz)", double> high_beta;
+    halp::val_port<"Gamma (30-50 Hz)", double> gamma;
+  } outputs;
+
+  void operator()();
+};
+
+}


### PR DESCRIPTION
### Summary

Implements the `Power Band EEG` processor. This node is a specialized version of the `PowerBand` processor that computes power for a set of fixed, standard EEG frequency bands (Delta, Theta, Alpha, etc.) simultaneously.

### Functionality

- Takes a PSD array and a corresponding frequencies array as input.
- Outputs the calculated power for each of the 6 standard EEG bands on dedicated output ports.
- Supports both absolute and relative power calculations.

### Implementation Notes

- This processor reuses the `calculate_power_in_band` helper function and dependencies introduced in the `PowerBand` PR.