### PR TITLE
Feature/normalizer

### DIFF
--- a/3rdparty/extras/CMakeLists.txt
+++ b/3rdparty/extras/CMakeLists.txt
@@ -8,5 +8,7 @@ add_library(extras
   PeakDetector.h
   helpers.cpp
   helpers.h
+  Normalizer.cpp
+  Normalizer.h
   EMA.h
 )

--- a/3rdparty/extras/EMA.h
+++ b/3rdparty/extras/EMA.h
@@ -1,4 +1,4 @@
- /*
+/*
  * EMA.h
  *
  * Small helpers for exponential moving averages with a time window

--- a/3rdparty/extras/Normalizer.cpp
+++ b/3rdparty/extras/Normalizer.cpp
@@ -117,20 +117,14 @@ float Normalizer::stddev() const
 
 float Normalizer::value() const { return _y; }
 
-float Normalizer::lowOutlierThreshold(float nStdDev) const
-{
-  return _targetMean - std::fabs(nStdDev) * _targetStd;
-}
-
-float Normalizer::highOutlierThreshold(float nStdDev) const
-{
-  return _targetMean + std::fabs(nStdDev) * _targetStd;
-}
-
 bool Normalizer::isOutlier(float value, float nStdDev) const
 {
-  return (value < lowOutlierThreshold(nStdDev)) ||
-         (value > highOutlierThreshold(nStdDev));
+  const float sd = stddev();
+  if (!(sd > 0.0f))
+    return false;
+
+  const float z = (value - _m1) / sd;
+  return std::fabs(z) >= std::fabs(nStdDev);
 }
 
 // ---- Main entry ------ //
@@ -146,16 +140,9 @@ float Normalizer::put(float x, double dt_seconds)
 // Initialize the internal state
 void Normalizer::init_states()
 {
-  if (_infinite) {
-    // Infinite mode: stats seeded from first sample.
-    _m1 = 0.0f;
-    _m2 = 0.0f;
-  } else {
-    // Finite mode: start from target prior.
-    _m1 = _targetMean;
-    _m2 = _targetMean * _targetMean + _targetStd * _targetStd;
-  }
-  _y = _targetMean;
+  _m1 = 0.0f;
+  _m2 = 0.0f;
+  _y  = _targetMean;
 }
 
 // Update running mean + second moment

--- a/3rdparty/extras/Normalizer.cpp
+++ b/3rdparty/extras/Normalizer.cpp
@@ -1,0 +1,209 @@
+/*
+ * Normalizer.cpp
+ *
+ * Adapté de : 
+ * Plaquette (c) 2022 Sofian Audry        :: info(@)sofianaudry(.)com
+ *
+ * Adaptation par Luana Belinsky 2025
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "Normalizer.h"
+
+#include <algorithm>
+#include <cmath>
+
+// ---- Constructors -----//
+
+Normalizer::Normalizer(float targetMean, float targetStd)
+  : _infinite(true)
+  , _tau_s(1.0)
+  , _targetMean(targetMean)
+  , _targetStd (std::fabs(targetStd))
+  , _reseed(true)  // start infinite mode seeded by first sample
+{
+  init_states();
+  clamp(kDefaultClampNSigmas);
+}
+
+Normalizer::Normalizer(double timeWindowSeconds, float targetMean, float targetStd)
+  : _infinite(timeWindowSeconds <= 0.0)
+  , _tau_s(_infinite ? 1.0 : timeWindowSeconds)
+  , _targetMean(targetMean)
+  , _targetStd (std::fabs(targetStd))
+  , _reseed(_infinite)  // reseed from first sample if infinite
+{
+  init_states();
+  clamp(kDefaultClampNSigmas);
+}
+
+// ---- Time window / decay control ------//
+
+void Normalizer::timeWindow(double seconds)
+{
+  const bool was_infinite = _infinite;
+  _infinite = (seconds <= 0.0);
+  _tau_s    = _infinite ? 1.0 : seconds;
+
+  // EMA → infinite: forget prior mass and reseed from the next sample
+  if (!was_infinite && _infinite) {
+    _n      = 0;
+    _reseed = true;
+  }
+}
+
+double Normalizer::timeWindow() const { return _infinite ? 0.0 : _tau_s; }
+bool   Normalizer::timeWindowIsInfinite() const { return _infinite; }
+
+// ---- Reset -----//
+
+void Normalizer::reset()
+{
+  // reset moments; for infinite, reseed from first sample
+  _n      = 0;
+  _reseed = _infinite;
+  init_states();
+}
+
+// ---- Targets ------//
+
+void  Normalizer::targetMean(float m)   { _targetMean = m; }
+float Normalizer::targetMean()    const { return _targetMean; }
+
+void  Normalizer::targetStdDev(float s) { _targetStd = std::fabs(s); }
+float Normalizer::targetStdDev()  const { return _targetStd; }
+
+// ---- Inspectors -----//
+
+float Normalizer::mean()     const { return _m1; }
+float Normalizer::variance() const
+{
+  const float v = _m2 - _m1 * _m1;
+  return (v > 0.0f) ? v : 0.0f;
+}
+float Normalizer::stddev()   const { return std::sqrt(variance()); }
+float Normalizer::value()    const { return _y; }
+
+// thresholds around target distribution
+float Normalizer::lowOutlierThreshold (float nStdDev) const
+{ return _targetMean - std::fabs(nStdDev) * _targetStd; }
+
+float Normalizer::highOutlierThreshold(float nStdDev) const
+{ return _targetMean + std::fabs(nStdDev) * _targetStd; }
+
+bool Normalizer::isOutlier(float value, float nStdDev) const
+{
+  return (value < lowOutlierThreshold(nStdDev)) ||
+         (value > highOutlierThreshold(nStdDev));
+}
+
+// ---- Main entry ------//
+
+float Normalizer::put(float x, double dt_seconds)
+{
+  // EMA coefficient from (tau, dt). Ignored in infinite mode.
+  const float a = _infinite ? 0.0f : alpha_from_tau_dt(_tau_s, dt_seconds);
+
+  update_stats(x, a);   // update E[x], E[x^2]
+  return finalize(x);   // z-score --> retarget --> clamp
+}
+
+// ---- Helpers ----------------------------------------------------------------
+
+// Convert (tau, dt) to EMA alpha: y <-- y + a*(x - y)
+// a = 1 - exp(-dt/tau).  tau --> infinite or dt --> 0 --> a≈0 (slow); small tau → larger a (fast).
+float Normalizer::alpha_from_tau_dt(double tau_s, double dt)
+{
+  if (tau_s <= 0.0 || dt <= 0.0) return 1.0f; // immediate (no smoothing)
+  const double x = -dt / tau_s;
+  return static_cast<float>(1.0 - std::exp(x));
+}
+
+// Initialize the internal state
+void Normalizer::init_states()
+{
+  if (_infinite) {
+    // cumulative mode --> start from data (first sample reseeds)
+    _m1 = 0.0f;
+    _m2 = 0.0f;
+  } else {
+    // EMA mode --> start from target prior
+    _m1 = _targetMean;
+    _m2 = _targetMean * _targetMean + _targetStd * _targetStd; // mean^2 + stddev^2
+  }
+  _y = _targetMean; // keep output centered initially
+}
+
+// Update running mean + second moment
+void Normalizer::update_stats(float x, float a)
+{
+  if (_infinite) {
+    // cumulative (no decay)
+    if (_reseed || _n == 0) {
+      _m1 = x;
+      _m2 = x * x;
+      _n  = 1;
+      _reseed = false;
+      return;
+    }
+    ++_n;
+    const float invN = 1.0f / static_cast<float>(_n);
+    _m1 += (x     - _m1) * invN;   // E[x]
+    _m2 += (x*x   - _m2) * invN;   // E[x^2]
+  } else {
+    // EMA (finite window)
+    a = std::clamp(a, 0.0f, 1.0f);
+    _m1 = (1.0f - a) * _m1 + a * x;        // E[x]
+    _m2 = (1.0f - a) * _m2 + a * (x * x);  // E[x^2]
+  }
+}
+
+// Compute normalized & mapped output
+// 1) z-score with current mean/std, 2) map to target mean/std, 3) optional clamp
+float Normalizer::finalize(float x)
+{
+  const float mu  = _m1;
+  const float var = std::max(0.0f, _m2 - mu * mu);
+  const float sd  = std::sqrt(var);
+
+  // If sd is ~0 (flat input), treat as zero-variance to avoid blow-ups.
+  const float z = (sd > 1e-12f) ? (x - mu) / sd : 0.0f;
+
+  // Retarget to desired output distribution
+  float y = _targetMean + z * _targetStd;
+
+  // Optional clamp around target mean
+  if (_doClamp)
+  {
+    const float r  = _clampNSig * _targetStd;
+    const float lo = _targetMean - r;
+    const float hi = _targetMean + r;
+    y = std::clamp(y, lo, hi);
+  }
+
+  _y = y;
+  return _y;
+}
+
+// ---- Clamp ------//
+
+void Normalizer::clamp(float nStdDev)
+{
+  _doClamp   = true;
+  _clampNSig = std::fabs(nStdDev);
+}
+
+void Normalizer::noClamp()         { _doClamp = false; }
+bool Normalizer::isClamped() const { return _doClamp; }

--- a/3rdparty/extras/Normalizer.h
+++ b/3rdparty/extras/Normalizer.h
@@ -85,10 +85,7 @@ public:
   float variance() const;
   float stddev() const;
   float value() const;
-
-  float lowOutlierThreshold(float nStdDev = 1.5f) const;
-  float highOutlierThreshold(float nStdDev = 1.5f) const;
-
+  
   bool isOutlier(float value, float nStdDev = 1.5f) const;
 
   // ---- Clamp ---- //

--- a/3rdparty/extras/Normalizer.h
+++ b/3rdparty/extras/Normalizer.h
@@ -1,0 +1,108 @@
+#pragma once
+
+/*
+ * Normalizer.h
+ *
+ * Adapté de : 
+ * Plaquette (c) 2022 Sofian Audry        :: info(@)sofianaudry(.)com
+ *
+ * Adaptation par Luana Belinsky 2025
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <cstdint>
+
+class Normalizer {
+public:
+  // defaults
+  static constexpr float  kDefaultTargetMean     = 0.0f;
+  static constexpr float  kDefaultTargetStdDev   = 1.0f;
+  static constexpr float  kDefaultClampNSigmas   = 3.0f;
+
+  // constructors
+  explicit Normalizer(float targetMean = kDefaultTargetMean,
+                      float targetStd  = kDefaultTargetStdDev);
+  Normalizer(double timeWindowSeconds,
+             float  targetMean = kDefaultTargetMean,
+             float  targetStd  = kDefaultTargetStdDev);
+
+  // time window / decay
+  void   timeWindow(double seconds);   // <=0 --> infinite
+  double timeWindow() const;           // 0 if infinite
+  bool   timeWindowIsInfinite() const;
+
+  // reset
+  void   reset();
+
+  // main entry: feed one sample with known dt (seconds)
+  float  put(float x, double dt_seconds);
+
+  // targets
+  void   targetMean(float m);
+  float  targetMean() const;
+
+  void   targetStdDev(float s);
+  float  targetStdDev() const;
+
+  // stats
+  float  mean() const;
+  float  variance() const;
+  float  stddev() const;
+
+  // last output
+  float  value() const;
+
+  // clamp
+  void   clamp(float nStdDev = kDefaultClampNSigmas);
+  void   noClamp();
+  bool   isClamped() const;
+
+  // outliers relative to target distribution
+  float  lowOutlierThreshold (float nStdDev) const;
+  float  highOutlierThreshold(float nStdDev) const;
+  bool   isOutlier(float value, float nStdDev) const;
+
+private:
+  // helpers
+  static float alpha_from_tau_dt(double tau_s, double dt);
+  void   init_states();                // initialize internal stats/output
+  void   update_stats(float x, float a);
+  float  finalize(float x);            // z-score --> retarget --> clamp
+
+private:
+  // config / targets
+  float   _targetMean = kDefaultTargetMean;
+  float   _targetStd  = kDefaultTargetStdDev;
+
+  // decay control
+  bool    _infinite = true;            // true --> cumulative (no decay)
+  double  _tau_s    = 1.0;             // EMA time constant (s) when finite
+
+  // cumulative-mode helpers
+  uint64_t _n      = 0;                // sample count in infinite mode
+  bool     _reseed = true;             // reseed from first sample after toggle
+
+  // running stats (moments)
+  float   _m1 = 0.0f;                  // E[x]
+  float   _m2 = 0.0f;                  // E[x^2]
+
+  // clamp
+  bool    _doClamp   = true;
+  float   _clampNSig = kDefaultClampNSigmas;
+
+  // last output
+  float   _y = 0.0f;
+};

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,8 @@ target_sources(score_addon_puara
   Puara/halp_utils.hpp
   3rdparty/extras/PeakDetector.h
   3rdparty/extras/PeakDetector.cpp
+  3rdparty/extras/Normalizer.h
+  3rdparty/extras/Normalizer.cpp
   3rdparty/extras/helpers.h
   3rdparty/extras/helpers.cpp
   3rdparty/extras/EMA.h
@@ -116,6 +118,16 @@ avnd_score_plugin_add(
     Puara/BioDataHeart.cpp
   TARGET puara_heart
   MAIN_CLASS BioData_Heart
+  NAMESPACE puara_gestures::objects
+)
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/Normalization.hpp
+    Puara/Normalization.cpp
+  TARGET puara_normalization
+  MAIN_CLASS Normalization
   NAMESPACE puara_gestures::objects
 )
 

--- a/Puara/Normalization.cpp
+++ b/Puara/Normalization.cpp
@@ -1,67 +1,89 @@
-
 #include "Normalization.hpp"
-#include <limits>
+
 #include <cmath>
+
+#include <limits>
 
 namespace puara_gestures::objects
 {
-// Adaptive CV: classic stddev/|mean| when |mean| is “large enough”, otherwise stddev/RMS.
-// - eps: hard floor to avoid divide-by-zero
-// - rel: how “large enough” |mean| must be vs stddev to stay in classic mode
-inline float adaptive_cv(float mu, float sd,
-                         float eps = 1e-6f,
-                         float rel = 5e-2f)  // 0.05 default
+// CV: stddev / mean
+// NOTE: Only valid for strictly positive signals.
+float Normalization::cv(float mu, float sd, float eps = 1e-6f)
 {
-  if (!(sd > 0.0f)) return 0.0f;
-
-  const float abs_mu = std::fabs(mu);
-  // If |mean| ≥ rel*stddev + eps → classic CV
-  if (abs_mu >= rel * sd + eps) {
-    return sd / abs_mu;
-  }
-
-  // Otherwise use RMS CV (bounded, well-defined even when mean≈0)
-  const float rms2 = sd * sd + mu * mu;     // E[x^2] = Var + mean^2
-  const float rms  = std::sqrt(rms2);
-  if (!(rms > 0.0f)) return 0.0f;
-  return sd / rms;                           // ∈ [0, 1]
+  if(!(sd > 0.0f))
+    return 0.0f;
+  if(std::fabs(mu) < eps)
+    return 0.0f; // avoid division by zero
+  return sd / mu;
 }
 
 void Normalization::prepare(halp::setup info)
 {
   setup = info;
 
-  norm = Normalizer(Normalizer::kDefaultTargetMean,
-                    Normalizer::kDefaultTargetStdDev);
+  norm = Normalizer(Normalizer::kDefaultTargetMean, Normalizer::kDefaultTargetStdDev);
 
   norm.targetMean(inputs.target_mean);
   norm.targetStdDev(inputs.target_std);
 
-  if (inputs.infinite_time_window)
-    norm.timeWindow(0.0f);          // 0 => infinite window
+  if(inputs.infinite_time_window)
+    norm.timeWindow(0.0f); // 0 => infinite window
   else
     norm.timeWindow(inputs.time_window);
 
-  if (inputs.clamp_enable)
+  if(inputs.clamp_enable)
     norm.clamp(inputs.clamp_nsig);
   else
     norm.noClamp();
+
+  // Initialize watchers to current UI state
+  mean_watch.last = inputs.target_mean;
+  mean_watch.first = false;
+  std_watch.last = inputs.target_std;
+  std_watch.first = false;
+  time_watch.last = inputs.time_window;
+  time_watch.first = false;
+  clamp_watch.last = inputs.clamp_nsig;
+  clamp_watch.first = false;
+  clamp_enable_watch.last = inputs.clamp_enable;
+  clamp_enable_watch.first = false;
+  infinite_watch.last = inputs.infinite_time_window;
+  infinite_watch.first = false;
 }
 
 void Normalization::operator()(halp::tick t)
 {
-  // live param updates
-  norm.targetMean(inputs.target_mean);
-  norm.targetStdDev(inputs.target_std);
-  norm.timeWindow(inputs.infinite_time_window ? 0.0f : inputs.time_window);
+  // live param updates (only when changed)
+  const bool mean_changed = mean_watch.changed(inputs.target_mean);
+  const bool std_changed = std_watch.changed(inputs.target_std);
+  const bool time_changed = time_watch.changed(inputs.time_window);
+  const bool clamp_changed = clamp_watch.changed(inputs.clamp_nsig);
+  const bool clamp_en_changed = clamp_enable_watch.changed(inputs.clamp_enable);
+  const bool inf_changed = infinite_watch.changed(inputs.infinite_time_window);
 
-  if (inputs.clamp_enable) norm.clamp(inputs.clamp_nsig); else norm.noClamp();
+  if(mean_changed)
+    norm.targetMean(inputs.target_mean);
+
+  if(std_changed)
+    norm.targetStdDev(inputs.target_std);
+
+  if(time_changed || inf_changed)
+    norm.timeWindow(inputs.infinite_time_window ? 0.0f : inputs.time_window);
+
+  if(clamp_en_changed || clamp_changed)
+  {
+    if(inputs.clamp_enable)
+      norm.clamp(inputs.clamp_nsig);
+    else
+      norm.noClamp();
+  }
 
   // --- compute dt (seconds) from tick ---
   float dt = 0;
-  if (setup.rate > 0.0) {
+  if(setup.rate > 0.0)
+  {
     const float maybe_dt = static_cast<float>(t.frames) / static_cast<float>(setup.rate);
-    if (maybe_dt > 0.f && maybe_dt < 0.1f)  // guard: 0 < dt < 100 ms
+    if(maybe_dt > 0.f)
       dt = maybe_dt;
   }
 
@@ -69,14 +91,14 @@ void Normalization::operator()(halp::tick t)
   const float y = norm.put(inputs.normalization_signal, static_cast<double>(dt));
 
   // outputs
-  outputs.out     = y;
-  outputs.mean    = norm.mean();
-  outputs.stddev  = norm.stddev();
+  outputs.out = y;
+  outputs.mean = norm.mean();
+  outputs.stddev = norm.stddev();
   outputs.outlier = norm.isOutlier(y, inputs.out_thresh);
 
-  // Adaptive CV: classic when |mean| big enough, RMS when |mean| small
-  const float mu  = outputs.mean;
-  const float sd  = outputs.stddev;
-  outputs.variation = adaptive_cv(mu, sd, 1e-6f, inputs.cv_rel);
+  // Classic coefficient of variation (positive signals only)
+  const float mu = outputs.mean;
+  const float sd = outputs.stddev;
+  outputs.variation = cv(mu, sd);
 }
-} // namespace
+} // namespace puara_gestures::objects

--- a/Puara/Normalization.cpp
+++ b/Puara/Normalization.cpp
@@ -8,7 +8,7 @@ namespace puara_gestures::objects
 {
 // CV: stddev / mean
 // NOTE: Only valid for strictly positive signals.
-float Normalization::cv(float mu, float sd, float eps = 1e-6f)
+float Normalization::cv(float mu, float sd, float eps)
 {
   if(!(sd > 0.0f))
     return 0.0f;

--- a/Puara/Normalization.cpp
+++ b/Puara/Normalization.cpp
@@ -1,0 +1,82 @@
+
+#include "Normalization.hpp"
+#include <limits>
+#include <cmath>
+
+namespace puara_gestures::objects
+{
+// Adaptive CV: classic stddev/|mean| when |mean| is “large enough”, otherwise stddev/RMS.
+// - eps: hard floor to avoid divide-by-zero
+// - rel: how “large enough” |mean| must be vs stddev to stay in classic mode
+inline float adaptive_cv(float mu, float sd,
+                         float eps = 1e-6f,
+                         float rel = 5e-2f)  // 0.05 default
+{
+  if (!(sd > 0.0f)) return 0.0f;
+
+  const float abs_mu = std::fabs(mu);
+  // If |mean| ≥ rel*stddev + eps → classic CV
+  if (abs_mu >= rel * sd + eps) {
+    return sd / abs_mu;
+  }
+
+  // Otherwise use RMS CV (bounded, well-defined even when mean≈0)
+  const float rms2 = sd * sd + mu * mu;     // E[x^2] = Var + mean^2
+  const float rms  = std::sqrt(rms2);
+  if (!(rms > 0.0f)) return 0.0f;
+  return sd / rms;                           // ∈ [0, 1]
+}
+
+void Normalization::prepare(halp::setup info)
+{
+  setup = info;
+
+  norm = Normalizer(Normalizer::kDefaultTargetMean,
+                    Normalizer::kDefaultTargetStdDev);
+
+  norm.targetMean(inputs.target_mean);
+  norm.targetStdDev(inputs.target_std);
+
+  if (inputs.infinite_time_window)
+    norm.timeWindow(0.0f);          // 0 => infinite window
+  else
+    norm.timeWindow(inputs.time_window);
+
+  if (inputs.clamp_enable)
+    norm.clamp(inputs.clamp_nsig);
+  else
+    norm.noClamp();
+}
+
+void Normalization::operator()(halp::tick t)
+{
+  // live param updates
+  norm.targetMean(inputs.target_mean);
+  norm.targetStdDev(inputs.target_std);
+  norm.timeWindow(inputs.infinite_time_window ? 0.0f : inputs.time_window);
+
+  if (inputs.clamp_enable) norm.clamp(inputs.clamp_nsig); else norm.noClamp();
+
+  // --- compute dt (seconds) from tick ---
+  float dt = 0;
+  if (setup.rate > 0.0) {
+    const float maybe_dt = static_cast<float>(t.frames) / static_cast<float>(setup.rate);
+    if (maybe_dt > 0.f && maybe_dt < 0.1f)  // guard: 0 < dt < 100 ms
+      dt = maybe_dt;
+  }
+
+  // --- process ---
+  const float y = norm.put(inputs.normalization_signal, static_cast<double>(dt));
+
+  // outputs
+  outputs.out     = y;
+  outputs.mean    = norm.mean();
+  outputs.stddev  = norm.stddev();
+  outputs.outlier = norm.isOutlier(y, inputs.out_thresh);
+
+  // Adaptive CV: classic when |mean| big enough, RMS when |mean| small
+  const float mu  = outputs.mean;
+  const float sd  = outputs.stddev;
+  outputs.variation = adaptive_cv(mu, sd, 1e-6f, inputs.cv_rel);
+}
+} // namespace

--- a/Puara/Normalization.hpp
+++ b/Puara/Normalization.hpp
@@ -1,13 +1,13 @@
-
 #pragma once
 #include "3rdparty/extras/Normalizer.h"
+#include "halp_utils.hpp"
 
-#include <limits>
 #include <halp/audio.hpp>
 #include <halp/controls.hpp>
 #include <halp/meta.hpp>
 #include <puara/gestures.h>
-#include "halp_utils.hpp"
+
+#include <limits>
 
 namespace puara_gestures::objects
 {
@@ -19,84 +19,70 @@ public:
   halp_meta(category, "Analysis/Data")
   halp_meta(c_name, "Normalizer")
   halp_meta(author, "Luana Belinsky (adapted from Sofian Audry’s Plaquette)")
-  halp_meta(description,
-    "Adaptive normalizer with a time window (seconds). "
-    "Maps input to a target mean & standard deviation.")
+  halp_meta(
+      description,
+      "Adaptive normalizer with a time window (seconds). "
+      "Maps input to a target mean & standard deviation.\n"
+      "Note: Coefficient of variation (CV) is computed as stddev / mean and "
+      "assumes a strictly positive signal.")
   halp_meta(manual_url, "https://plaquette.org/Normalizer.html")
   halp_meta(uuid, "c6f3f2d3-6f37-4e3f-8db6-0a5a4d9f7a01")
 
-struct
-{
-  halp::data_port<
-      "Signal",
-      "Input signal to normalize",
-      float>
-      normalization_signal;
+  struct
+  {
+    halp::data_port<"Signal", "Input signal to normalize", float> normalization_signal;
 
-  halp::knob_f32<"Target mean",
-                  halp::range{0.0, 1.0, 0.5}>
-      target_mean; //Desired output mean after normalization
+    halp::knob_f32<"Target mean", halp::range{0.0, 1.0, 0.5}>
+        target_mean; //Desired output mean after normalization
 
-  halp::knob_f32<"Target std dev",
-                  halp::range{0.0, 5.0, 0.15}>
-      target_std; //Desired output standard deviation
+    halp::knob_f32<"Target std dev", halp::range{0.0, 10.0, 0.15}>
+        target_std; //Desired output standard deviation (range expanded for flexibility)
 
-  halp::knob_f32<"Time window (s)",
-                  halp::range{0.01, 360.0, 1.0}>
-      time_window; //EMA window for stats (seconds)
+    halp::knob_f32<"Time window (s)", halp::range{0.01, 360.0, 1.0}>
+        time_window; //EMA window for stats (seconds)
 
-  halp::toggle<"Infinite time window">
-      infinite_time_window{false}; // Track stats over all time (no decay)
+    halp::toggle<"Infinite time window"> infinite_time_window{
+        false}; // Track stats over all time (no decay)
 
-  halp::knob_f32<"Outlier threshold",
-                  halp::range{0.0, 10.0, 1.5}>
-      out_thresh; //n·stddev used to flag outliers
+    halp::knob_f32<"Outlier threshold", halp::range{0.0, 10.0, 1.5}>
+        out_thresh; //n·stddev used to flag outliers
 
-  halp::toggle<"Clamp output">
-      clamp_enable{true}; //Limit output to mean ± n·stddev
+    halp::toggle<"Clamp output"> clamp_enable{true}; //Limit output to mean ± n·stddev
 
-  halp::knob_f32<"Clamp max",
-                  halp::range{0.10, 5.00, 3.33}>
-      clamp_nsig; //n·stddev used for clamp range
+    halp::knob_f32<"Clamp max", halp::range{0.10, 5.00, 3.33}>
+        clamp_nsig; //n·stddev used for clamp range
 
-  halp::knob_f32<"CV switch sensitivity",
-                  halp::range{0.0, 0.5, 0.05}>
-      cv_rel; //Min relative change to toggle CV
-} inputs;
+  } inputs;
 
-struct
-{
+  struct
+  {
     halp::data_port<
         "Normalized signal",
-        "Float. Input remapped to the target mean and standard deviation.",
-        float>
+        "Float. Input remapped to the target mean and standard deviation.", float>
         out;
 
-    halp::data_port<
-        "Mean",
-        "Float. Current running mean of the input signal.",
-        float>
+    halp::data_port<"Mean", "Float. Current running mean of the input signal.", float>
         mean;
 
     halp::data_port<
-        "Standard deviation",
-        "Float. Current standard deviation of the input signal.",
+        "Standard deviation", "Float. Current standard deviation of the input signal.",
         float>
         stddev;
 
     halp::data_port<
         "Outlier",
-        "Boolean. True when the normalized value exceeds the outlier limits set as ±N standard deviations from the target mean.",
+        "Boolean. True when the normalized value exceeds the outlier limits set as ±N "
+        "standard deviations from the target mean.",
         bool>
         outlier;
 
     halp::data_port<
         "Coefficient of variation",
         "Float. Ratio of standard deviation to mean.\n"
-        "Useful to track relative variability independent of scale.",
+        "Only valid for strictly positive signals.",
         float>
         variation;
-} outputs;
+  } outputs;
 
   halp::setup setup;
   void prepare(halp::setup info);
@@ -105,8 +91,17 @@ struct
   void operator()(halp::tick t);
 
 private:
-  Normalizer norm{Normalizer::kDefaultTargetMean,
-                  Normalizer::kDefaultTargetStdDev};
+  Normalizer norm{Normalizer::kDefaultTargetMean, Normalizer::kDefaultTargetStdDev};
 
+  // Classic CV: stddev / mean (only valid for positive signals)
+  float cv(float mu, float sd, float eps = 1e-6f);
+
+  // Parameter watchers 
+  halp::ParameterWatcher<float> mean_watch;
+  halp::ParameterWatcher<float> std_watch;
+  halp::ParameterWatcher<float> time_watch;
+  halp::ParameterWatcher<float> clamp_watch;
+  halp::ParameterWatcher<bool>  clamp_enable_watch;
+  halp::ParameterWatcher<bool>  infinite_watch;
 };
-} // namespace
+} // namespace puara_gestures::objects

--- a/Puara/Normalization.hpp
+++ b/Puara/Normalization.hpp
@@ -1,0 +1,112 @@
+
+#pragma once
+#include "3rdparty/extras/Normalizer.h"
+
+#include <limits>
+#include <halp/audio.hpp>
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+#include <puara/gestures.h>
+#include "halp_utils.hpp"
+
+namespace puara_gestures::objects
+{
+// normalizer
+class Normalization
+{
+public:
+  halp_meta(name, "Normalizer")
+  halp_meta(category, "Analysis/Data")
+  halp_meta(c_name, "Normalizer")
+  halp_meta(author, "Luana Belinsky (adapted from Sofian Audry’s Plaquette)")
+  halp_meta(description,
+    "Adaptive normalizer with a time window (seconds). "
+    "Maps input to a target mean & standard deviation.")
+  halp_meta(manual_url, "https://plaquette.org/Normalizer.html")
+  halp_meta(uuid, "c6f3f2d3-6f37-4e3f-8db6-0a5a4d9f7a01")
+
+struct
+{
+  halp::data_port<
+      "Signal",
+      "Input signal to normalize",
+      float>
+      normalization_signal;
+
+  halp::knob_f32<"Target mean",
+                  halp::range{0.0, 1.0, 0.5}>
+      target_mean; //Desired output mean after normalization
+
+  halp::knob_f32<"Target std dev",
+                  halp::range{0.0, 5.0, 0.15}>
+      target_std; //Desired output standard deviation
+
+  halp::knob_f32<"Time window (s)",
+                  halp::range{0.01, 360.0, 1.0}>
+      time_window; //EMA window for stats (seconds)
+
+  halp::toggle<"Infinite time window">
+      infinite_time_window{false}; // Track stats over all time (no decay)
+
+  halp::knob_f32<"Outlier threshold",
+                  halp::range{0.0, 10.0, 1.5}>
+      out_thresh; //n·stddev used to flag outliers
+
+  halp::toggle<"Clamp output">
+      clamp_enable{true}; //Limit output to mean ± n·stddev
+
+  halp::knob_f32<"Clamp max",
+                  halp::range{0.10, 5.00, 3.33}>
+      clamp_nsig; //n·stddev used for clamp range
+
+  halp::knob_f32<"CV switch sensitivity",
+                  halp::range{0.0, 0.5, 0.05}>
+      cv_rel; //Min relative change to toggle CV
+} inputs;
+
+struct
+{
+    halp::data_port<
+        "Normalized signal",
+        "Float. Input remapped to the target mean and standard deviation.",
+        float>
+        out;
+
+    halp::data_port<
+        "Mean",
+        "Float. Current running mean of the input signal.",
+        float>
+        mean;
+
+    halp::data_port<
+        "Standard deviation",
+        "Float. Current standard deviation of the input signal.",
+        float>
+        stddev;
+
+    halp::data_port<
+        "Outlier",
+        "Boolean. True when the normalized value exceeds the outlier limits set as ±N standard deviations from the target mean.",
+        bool>
+        outlier;
+
+    halp::data_port<
+        "Coefficient of variation",
+        "Float. Ratio of standard deviation to mean.\n"
+        "Useful to track relative variability independent of scale.",
+        float>
+        variation;
+} outputs;
+
+  halp::setup setup;
+  void prepare(halp::setup info);
+
+  using tick = halp::tick;
+  void operator()(halp::tick t);
+
+private:
+  Normalizer norm{Normalizer::kDefaultTargetMean,
+                  Normalizer::kDefaultTargetStdDev};
+
+};
+} // namespace


### PR DESCRIPTION
### Summary
Adds an adaptive normalization utility for real-time signals. The module continuously tracks running mean/variance (either cumulatively or via an EMA time window) and remaps the input to a configurable target mean and target standard deviation. Optional clamping enforces bounded output (± N·stddev). The object also reports raw stats, outlier flags, and coefficient of variation (CV).
Adapted from Sofian Audry’s [Plaquette implementation](https://sofapirate.github.io/Plaquette/Normalizer.html).

### Functionality
Inputs are : 
- Signal(int or float)

Parameters are : 
- Target mean (float) — desired output mean
- Target std dev (float) — desired output standard deviation
- Time window (s) (float) — EMA window for stats; dt inferred per tick; 0 / toggle → infinite
- Infinite time window (bool) — cumulative mode (no decay)
- Clamp output (bool) — enables bounding around target mean
- Clamp max (N·stddev) (float) — clamp range
- Outlier threshold (N·stddev) (float) — outlier detection

Outputs are : 
- Normalized signal (float) — remapped normalized signal
- Mean (float) — current running mean
- Standard deviation (float) — current stddev
- Outlier (bool) — true when outside ± N·stddev
- Coefficient of variation (float) — computed as stddev / mean (only valid for strictly positive signals, returns zero when mean approaches zero)

### Implementation notes
Uses a Normalizer custom class stored in 3rdparty/extras (to be reused in Respiration and EDA processes)
