### PR TITLE
Feature/rate of change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,17 @@ avnd_score_plugin_add(
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
   SOURCES
+    Puara/RateOfChange.hpp
+    Puara/RateOfChange.cpp
+  TARGET puara_rate_of_change
+  MAIN_CLASS RateOfChange
+  NAMESPACE puara_gestures::objects
+)
+
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
     Puara/Roll.hpp
     Puara/Roll.cpp
   TARGET puara_roll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,8 @@ target_sources(score_addon_puara
   3rdparty/extras/PeakDetector.cpp
   3rdparty/extras/Normalizer.h
   3rdparty/extras/Normalizer.cpp
+  3rdparty/extras/Normalizer.h
+  3rdparty/extras/Normalizer.cpp
   3rdparty/extras/helpers.h
   3rdparty/extras/helpers.cpp
   3rdparty/extras/EMA.h

--- a/Puara/RateOfChange.cpp
+++ b/Puara/RateOfChange.cpp
@@ -1,0 +1,174 @@
+#include "RateOfChange.hpp"
+
+#include <algorithm>
+#include <cmath> // std::isfinite
+
+namespace puara_gestures::objects
+{
+
+// tiny guard for denominator: avoid division by zero
+static constexpr double kDtEps = 1e-12;
+
+//==============Ring-buffer helpers==================//
+// returns the nth newest sample, n = 0 is newest
+const RateOfChange::Sample&
+RateOfChange::nth_newest_sample(std::size_t n) const
+{
+  // logical order: oldest = _buf[_head], newest = _buf[(_head + _size - 1) % _physCap]
+  // nth newest index = newest_index - n
+  const std::size_t pos = (_head + _size - 1 - n) % _physCap;
+  return _buf[pos];
+}
+
+// drop the oldest sample from the window
+void RateOfChange::drop_oldest_sample()
+{
+  if (_size <= 1)
+    return; // nothing to drop or only one sample; keep at least the oldest
+
+  std::size_t new_head = (_head + 1) % _physCap;
+
+  // new oldest is at new_head, so its dt becomes excluded from denominator
+  _sumDt -= _buf[new_head].dt;
+
+  _head = new_head;
+  --_size;
+}
+
+//==================Push sample into buffer=============================//
+// push a new sample into the ring buffer
+void RateOfChange::push(float x, double dt)
+{
+  // first sample: its dt does not contribute to the denominator
+  if (_size == 0)
+  {
+    _buf[0] = {x, 0.0};
+    _size   = 1;
+    return;
+  }
+
+  // if physically full, drop oldest sample before writing
+  if (_size == _physCap)
+  {
+    drop_oldest_sample();
+  }
+
+  // append at tail (newest sample)
+  const std::size_t tail = (_head + _size) % _physCap;
+  _buf[tail] = {x, dt};
+  ++_size;
+
+  // dt of newly added sample contributes to sum of dt 
+  _sumDt += dt;
+}
+
+//=============Window policy: decides which samples stay==========//
+// enforce sample window: keep at most N newest samples
+void RateOfChange::apply_window_policy()
+{
+  if (_cap < 2)
+    _cap = 2;
+
+    while (_size > _cap)
+    {
+      drop_oldest_sample();
+    }
+}
+
+//=================Parameter watcher==============//
+void RateOfChange::update_window_from_params()
+{
+  int   sample_window_v = inputs.sample_window.value;
+  if (sample_window_size.changed(sample_window_v))
+  {
+    if (sample_window_v < 2)
+    sample_window_v = 2;
+
+  // logical limit (how many newest samples we are allowed to keep)
+  _cap = sample_window_v;
+  }
+}
+
+//===========Derivative===============//
+// derivative across the current window: (x_last - x_first) / sum(dt)
+// "base" is in units of per-second; unit scaling is applied afterwards
+float RateOfChange::delta_per(int unit) const
+{
+  if (_size < 2 || !(_sumDt > kDtEps))       
+    return 0.0f;
+
+  const Sample& a = _buf[_head];              // oldest
+  const Sample& b = nth_newest_sample(0);     // newest
+
+  const double dx   = static_cast<double>(b.x) - static_cast<double>(a.x);
+  const double base = dx / _sumDt;            // per second
+
+  if (!std::isfinite(base))
+    return 0.0f;
+
+  float v = static_cast<float>(base);
+
+  switch (unit)
+  {
+    case PerMillisecond:
+      v *= 1.0f / 1000.0f;  // per-ms
+      break;
+    case PerSecond:
+      // as-is
+      break;
+    case PerMinute:
+      v *= 60.0f;           // per-min
+      break;
+    case PerHour:
+      v *= 3600.0f;         // per-hr
+      break;
+    default:
+      break;
+  }
+
+  return v;
+}
+
+//=============Score integration==================//
+void RateOfChange::prepare(halp::setup info)
+{
+  setup = info;
+
+  _buf.assign(_physCap, Sample{0.0f, 0.0});
+  _cap  = static_cast<std::size_t>(inputs.sample_window.value);
+  _head = 0;
+  _size = 0;
+  _sumDt = 0.0;
+
+  // init watcher 
+  sample_window_size.last  = inputs.sample_window.value;
+  sample_window_size.first = false;
+}
+
+void RateOfChange::operator()(halp::tick t)
+{
+  // update internal window config according to current parameters
+  update_window_from_params();
+
+  // compute dt from tick (seconds)
+  double dt = 0.0;
+  if (setup.rate > 0.0)
+  {
+    dt = static_cast<double>(t.frames) / setup.rate;
+    if (dt < 0.0)
+      dt = 0.0;
+  }
+
+  const float x = inputs.signal;
+
+  // push new sample
+  push(x, dt);
+
+  // enforce window policy
+  apply_window_policy();
+
+  // compute derivative in chosen units
+  outputs.out  = delta_per(inputs.output_units.value);
+}
+
+} // namespace puara_gestures::objects

--- a/Puara/RateOfChange.cpp
+++ b/Puara/RateOfChange.cpp
@@ -1,7 +1,8 @@
 #include "RateOfChange.hpp"
 
-#include <algorithm>
 #include <cmath> // std::isfinite
+
+#include <algorithm>
 
 namespace puara_gestures::objects
 {
@@ -11,11 +12,8 @@ static constexpr double kDtEps = 1e-12;
 
 //==============Ring-buffer helpers==================//
 // returns the nth newest sample, n = 0 is newest
-const RateOfChange::Sample&
-RateOfChange::nth_newest_sample(std::size_t n) const
+const RateOfChange::Sample& RateOfChange::nth_newest_sample(std::size_t n) const
 {
-  // logical order: oldest = _buf[_head], newest = _buf[(_head + _size - 1) % _physCap]
-  // nth newest index = newest_index - n
   const std::size_t pos = (_head + _size - 1 - n) % _physCap;
   return _buf[pos];
 }
@@ -23,13 +21,14 @@ RateOfChange::nth_newest_sample(std::size_t n) const
 // drop the oldest sample from the window
 void RateOfChange::drop_oldest_sample()
 {
-  if (_size <= 1)
-    return; // nothing to drop or only one sample; keep at least the oldest
+  if(_size <= 1)
+    return; // keep at least one sample for holding value
 
   std::size_t new_head = (_head + 1) % _physCap;
 
   // new oldest is at new_head, so its dt becomes excluded from denominator
   _sumDt -= _buf[new_head].dt;
+  _sumTime -= _buf[new_head].dt;
 
   _head = new_head;
   --_size;
@@ -39,53 +38,147 @@ void RateOfChange::drop_oldest_sample()
 // push a new sample into the ring buffer
 void RateOfChange::push(float x, double dt)
 {
-  // first sample: its dt does not contribute to the denominator
-  if (_size == 0)
-  {
-    _buf[0] = {x, 0.0};
-    _size   = 1;
-    return;
-  }
+  // Update last value and time
+  _lastValue = x;
+  _lastValueTime = _totalTime + dt;
 
-  // if physically full, drop oldest sample before writing
-  if (_size == _physCap)
+  // If physically full, drop oldest (but keep at least 1)
+  if(_size == _physCap)
   {
     drop_oldest_sample();
   }
 
-  // append at tail (newest sample)
+  // Append at tail (newest sample)
   const std::size_t tail = (_head + _size) % _physCap;
-  _buf[tail] = {x, dt};
+  _buf[tail] = {x, dt, _totalTime + dt};
   ++_size;
 
-  // dt of newly added sample contributes to sum of dt 
+  // dt of newly added sample contributes to sums
   _sumDt += dt;
+  _sumTime += dt;
+
+  // update absolute time
+  _totalTime += dt;
 }
 
 //=============Window policy: decides which samples stay==========//
-// enforce sample window: keep at most N newest samples
+// enforce window based on current mode
 void RateOfChange::apply_window_policy()
 {
-  if (_cap < 2)
-    _cap = 2;
+  if(inputs.window_mode == WindowMode::SampleCount)
+  {
+    // Sample count mode - simple
+    if(_cap < 2)
+      _cap = 2;
 
-    while (_size > _cap)
+    while(_size > _cap)
     {
       drop_oldest_sample();
     }
+  }
+  else // WindowMode::TimeWindow
+  {
+    // Time window mode with value holding
+    if(_maxTime < kDtEps)
+      _maxTime = kDtEps;
+
+    // We always need at least 1 sample (the held value)
+    if(_size == 0)
+      return;
+
+    // Ensure we have at least 2 samples for rate calculation
+    // If we only have 1, duplicate it (creates flat signal)
+    if(_size == 1)
+    {
+      // Duplicate the single sample at current time
+      const std::size_t tail = (_head + _size) % _physCap;
+      _buf[tail] = {_lastValue, 0.0, _totalTime}; // dt = 0, same time
+      ++_size;
+      // _sumDt stays 0, _sumTime stays 0
+      return;
+    }
+
+    // Now we have at least 2 samples
+
+    // Calculate time span from oldest to newest
+    double newestTime = nth_newest_sample(0).t;
+    double oldestTime = _buf[_head].t;
+    double windowSpan = newestTime - oldestTime;
+
+    // If window span exceeds max time, we need to adjust
+    if(windowSpan > _maxTime)
+    {
+      // Option 1: Drop oldest samples until window fits
+      // But we must keep at least 2 samples
+      while(_size > 2 && windowSpan > _maxTime)
+      {
+        drop_oldest_sample();
+
+        if(_size >= 2)
+        {
+          newestTime = nth_newest_sample(0).t;
+          oldestTime = _buf[_head].t;
+          windowSpan = newestTime - oldestTime;
+        }
+      }
+
+      // If after dropping we still have too large a window,
+      // it means our two samples are too far apart
+      if(_size >= 2 && windowSpan > _maxTime)
+      {
+        // Replace oldest sample with a synthetic sample
+        // that's exactly _maxTime seconds before newest
+        double targetOldestTime = newestTime - _maxTime;
+
+        // Update oldest sample
+        double newDt = newestTime - targetOldestTime;
+        _buf[_head] = {_lastValue, newDt, targetOldestTime};
+
+        // Recalculate sums
+        _sumDt = newDt; // Only one dt between the two samples
+        _sumTime = newDt;
+        // windowSpan is now exactly _maxTime
+      }
+    }
+  }
 }
 
 //=================Parameter watcher==============//
 void RateOfChange::update_window_from_params()
 {
-  int   sample_window_v = inputs.sample_window.value;
-  if (sample_window_size.changed(sample_window_v))
+  // Check if window mode changed
+  if(window_mode_watcher.changed(inputs.window_mode))
   {
-    if (sample_window_v < 2)
-    sample_window_v = 2;
+    // When switching modes, we need to apply the new policy
+    apply_window_policy();
+  }
 
-  // logical limit (how many newest samples we are allowed to keep)
-  _cap = sample_window_v;
+  if(inputs.window_mode == WindowMode::SampleCount)
+  {
+    // Sample count mode
+    int sample_count_v = inputs.sample_count;
+    if(sample_count_watcher.changed(sample_count_v))
+    {
+      if(sample_count_v < 2)
+        sample_count_v = 2;
+
+      _cap = static_cast<std::size_t>(sample_count_v);
+      apply_window_policy();
+    }
+  }
+  else // WindowMode::TimeWindow
+  {
+    // Time window mode
+    int time_window_ms = static_cast<int>(inputs.time_window * 1000.0f);
+    if(time_window_watcher.changed(time_window_ms))
+    {
+      float time_window_v = static_cast<float>(inputs.time_window);
+      if(time_window_v < kDtEps)
+        time_window_v = static_cast<float>(kDtEps);
+
+      _maxTime = static_cast<double>(time_window_v);
+      apply_window_policy();
+    }
   }
 }
 
@@ -94,33 +187,48 @@ void RateOfChange::update_window_from_params()
 // "base" is in units of per-second; unit scaling is applied afterwards
 float RateOfChange::delta_per(int unit) const
 {
-  if (_size < 2 || !(_sumDt > kDtEps))       
-    return 0.0f;
+  // Need at least 2 samples to compute rate
+  if(_size < 2)
+    return 0.0f; // Not enough data → rate = 0
 
-  const Sample& a = _buf[_head];              // oldest
-  const Sample& b = nth_newest_sample(0);     // newest
+  // Denominator check
+  if(!(_sumDt > kDtEps))
+  {
+    // If dt is 0, rate is either infinite or undefined
+    // For held values (identical timestamps), rate should be 0
+    const Sample& a = _buf[_head];
+    const Sample& b = nth_newest_sample(0);
 
-  const double dx   = static_cast<double>(b.x) - static_cast<double>(a.x);
-  const double base = dx / _sumDt;            // per second
+    if(a.x == b.x)
+      return 0.0f; // No change in value
+    else
+      return 0.0f; // Could also return large number, but 0 is safer
+  }
 
-  if (!std::isfinite(base))
+  const Sample& a = _buf[_head];          // oldest
+  const Sample& b = nth_newest_sample(0); // newest
+
+  const double dx = static_cast<double>(b.x) - static_cast<double>(a.x);
+  const double base = dx / _sumDt; // per second
+
+  if(!std::isfinite(base))
     return 0.0f;
 
   float v = static_cast<float>(base);
 
-  switch (unit)
+  switch(unit)
   {
     case PerMillisecond:
-      v *= 1.0f / 1000.0f;  // per-ms
+      v *= 1.0f / 1000.0f; // per-ms
       break;
     case PerSecond:
       // as-is
       break;
     case PerMinute:
-      v *= 60.0f;           // per-min
+      v *= 60.0f; // per-min
       break;
     case PerHour:
-      v *= 3600.0f;         // per-hr
+      v *= 3600.0f; // per-hr
       break;
     default:
       break;
@@ -134,15 +242,32 @@ void RateOfChange::prepare(halp::setup info)
 {
   setup = info;
 
-  _buf.assign(_physCap, Sample{0.0f, 0.0});
-  _cap  = static_cast<std::size_t>(inputs.sample_window.value);
+  _buf.assign(_physCap, Sample{0.0f, 0.0, 0.0});
+
+  // Initialize from inputs
+  _cap = static_cast<std::size_t>(inputs.sample_count);
+  _maxTime = static_cast<double>(inputs.time_window);
+
   _head = 0;
   _size = 0;
   _sumDt = 0.0;
+  _sumTime = 0.0;
+  _totalTime = 0.0;
+  _lastValue = 0.0f;
+  _lastValueTime = 0.0;
 
-  // init watcher 
-  sample_window_size.last  = inputs.sample_window.value;
-  sample_window_size.first = false;
+  // init watchers
+  window_mode_watcher.last = inputs.window_mode;
+  window_mode_watcher.first = false;
+
+  sample_count_watcher.last = inputs.sample_count;
+  sample_count_watcher.first = false;
+
+  time_window_watcher.last = static_cast<int>(inputs.time_window * 1000.0f);
+  time_window_watcher.first = false;
+
+  output_units_watcher.last = inputs.output_units.value;
+  output_units_watcher.first = false;
 }
 
 void RateOfChange::operator()(halp::tick t)
@@ -152,23 +277,27 @@ void RateOfChange::operator()(halp::tick t)
 
   // compute dt from tick (seconds)
   double dt = 0.0;
-  if (setup.rate > 0.0)
+  if(setup.rate > 0.0)
   {
     dt = static_cast<double>(t.frames) / setup.rate;
-    if (dt < 0.0)
+    if(dt < 0.0)
       dt = 0.0;
   }
 
   const float x = inputs.signal;
 
-  // push new sample
+  // push new sample (even if value hasn't changed)
   push(x, dt);
 
   // enforce window policy
   apply_window_policy();
 
   // compute derivative in chosen units
-  outputs.out  = delta_per(inputs.output_units.value);
+  outputs.out = delta_per(inputs.output_units.value);
+
+  // update diagnostic outputs
+  outputs.actual_samples = static_cast<int>(_size);
+  outputs.actual_time = static_cast<float>(_sumTime);
 }
 
 } // namespace puara_gestures::objects

--- a/Puara/RateOfChange.hpp
+++ b/Puara/RateOfChange.hpp
@@ -4,25 +4,23 @@
 #include <halp/controls.hpp>
 #include <halp/meta.hpp>
 
-#include <vector>
-#include <cstddef>
 #include <cmath>
+
+#include <cstddef>
+#include <vector>
 
 namespace puara_gestures::objects
 {
-// rate of change
+// rate of change with sample count OR time window
 class RateOfChange
 {
 public:
-  halp_meta(name, "Rate of change")
-  halp_meta(category, "Analysis/Data")
-  halp_meta(c_name, "Rate of change")
-  halp_meta(author, "Luana Belinsky")
-  halp_meta(
-      description,
-      "Calculates the rate of change (delta) of an input signal. "
-      "Supports a fixed sample window or a time window, and output in different time units.")
-  halp_meta(uuid, "7137a3bc-b3c0-43bc-9774-61c0e272db71")
+  //==== window mode ===//
+  enum class WindowMode
+  {
+    SampleCount, ///< Use fixed number of samples
+    TimeWindow   ///< Use fixed time window
+  };
 
   //==== output units (used by combobox) ===//
   enum
@@ -33,33 +31,59 @@ public:
     PerHour
   };
 
+  halp_meta(name, "Rate of change")
+  halp_meta(category, "Analysis/Data")
+  halp_meta(c_name, "rate_of_change")
+  halp_meta(author, "Luana Belinsky")
+  halp_meta(
+      description,
+      "Calculates the rate of change (delta) of an input signal. "
+      "Supports either a fixed sample window OR a time window, and output in different "
+      "time units. "
+      "When using time window mode, if no new data arrives, the last value is held "
+      "constant.")
+  halp_meta(uuid, "7137a3bc-b3c0-43bc-9774-61c0e272db71")
+
   struct
   {
     // Signal input
     halp::data_port<"Signal", "Int or float. Input signal to analyze", float> signal;
 
-    // Sample window (N) 
-    halp::spinbox_i32<"Sample window (N)", halp::range{2, 1000000, 1}> sample_window{2};
+    // Window mode selection using enum_t
+    halp::enum_t<WindowMode, "Window mode"> window_mode{WindowMode::SampleCount};
 
-    // Output units
+    // Sample window (N) - visible when WindowMode::SampleCount is selected
+    halp::spinbox_i32<"Sample count", halp::range{2, 1000000, 50}> sample_count;
+
+    // Time window (seconds) - visible when WindowMode::TimeWindow is selected
+    halp::spinbox_f32<"Time window (s)", halp::range{0.001, 3600.0, 1.0}> time_window;
+
+    // Output units using combobox style
     struct
     {
       halp__enum_combobox(
           "Output units",
-          PerSecond,        // default
-          PerMillisecond,
-          PerSecond,
-          PerMinute,
-          PerHour)
+          PerSecond, // default
+          PerMillisecond, PerSecond, PerMinute, PerHour)
     } output_units;
+
   } inputs;
 
   struct
   {
-    halp::data_port<"Rate of change (delta/time)",
-                    "Float. Units as per 'Output units'.",
-                    float>
+    halp::data_port<
+        "Rate of change (delta/time)", "Float. Units as per 'Output units'.", float>
         out;
+
+    // Diagnostic outputs
+    halp::data_port<
+        "Actual samples in window", "Int. Current number of samples in analysis window.",
+        int>
+        actual_samples;
+    halp::data_port<
+        "Actual window time span (s)",
+        "Float. Actual time span covered by window in seconds.", float>
+        actual_time;
   } outputs;
 
   halp::setup setup;
@@ -72,20 +96,26 @@ public:
   float delta_per(int unit) const;
 
 private:
-  // each sample pair contains value and dt
+  // each sample pair contains value, dt, and absolute time
   struct Sample
   {
-    float  x;   // value
-    double dt;  // delta time since previous sample (seconds)
+    float x;   // value
+    double dt; // delta time since previous sample (seconds)
+    double t;  // absolute time since start (seconds)
   };
 
   // ring buffer storage
   std::vector<Sample> _buf;
   const std::size_t _physCap = 1000000; // physical capacity (allocated size)
-  std::size_t _cap     = 0; // logical max samples 
-  std::size_t _head    = 0; // index of oldest in ring
-  std::size_t _size    = 0; // number of valid samples in window (<= _physCap)
-  double      _sumDt   = 0.0; // sum of dt for all samples except the oldest
+  std::size_t _cap = 0;                 // logical max samples (for sample count mode)
+  std::size_t _head = 0;                // index of oldest in ring
+  std::size_t _size = 0;       // number of valid samples in window (<= _physCap)
+  double _sumDt = 0.0;         // sum of dt for all samples except the oldest
+  double _sumTime = 0.0;       // total time span of window (sum of all dt)
+  double _maxTime = 1.0;       // maximum time window (seconds)
+  double _totalTime = 0.0;     // absolute time since start
+  float _lastValue = 0.0f;     // Last received value (for holding)
+  double _lastValueTime = 0.0; // When we last received a value
 
   // ---------- helpers ---------- //
   // return a const reference to the nth newest sample (0 = newest)
@@ -97,14 +127,17 @@ private:
   // push one new sample (x, dt) into the ring buffer
   void push(float x, double dt);
 
-  // enforce sample window
+  // enforce window policy based on current mode
   void apply_window_policy();
 
   // react to changes in parameters
   void update_window_from_params();
 
   // parameter watchers
-  halp::ParameterWatcher<int> sample_window_size;
+  halp::ParameterWatcher<int> sample_count_watcher;
+  halp::ParameterWatcher<int> time_window_watcher;
+  halp::ParameterWatcher<WindowMode> window_mode_watcher;
+  halp::ParameterWatcher<int> output_units_watcher;
 };
 
 } // namespace puara_gestures::objects

--- a/Puara/RateOfChange.hpp
+++ b/Puara/RateOfChange.hpp
@@ -1,0 +1,110 @@
+#pragma once
+#include "halp_utils.hpp"
+
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+
+#include <vector>
+#include <cstddef>
+#include <cmath>
+
+namespace puara_gestures::objects
+{
+// rate of change
+class RateOfChange
+{
+public:
+  halp_meta(name, "Rate of change")
+  halp_meta(category, "Analysis/Data")
+  halp_meta(c_name, "Rate of change")
+  halp_meta(author, "Luana Belinsky")
+  halp_meta(
+      description,
+      "Calculates the rate of change (delta) of an input signal. "
+      "Supports a fixed sample window or a time window, and output in different time units.")
+  halp_meta(uuid, "7137a3bc-b3c0-43bc-9774-61c0e272db71")
+
+  //==== output units (used by combobox) ===//
+  enum
+  {
+    PerMillisecond,
+    PerSecond,
+    PerMinute,
+    PerHour
+  };
+
+  struct
+  {
+    // Signal input
+    halp::data_port<"Signal", "Int or float. Input signal to analyze", float> signal;
+
+    // Sample window (N) 
+    halp::spinbox_i32<"Sample window (N)", halp::range{2, 1000000, 1}> sample_window{2};
+
+    // Output units
+    struct
+    {
+      halp__enum_combobox(
+          "Output units",
+          PerSecond,        // default
+          PerMillisecond,
+          PerSecond,
+          PerMinute,
+          PerHour)
+    } output_units;
+  } inputs;
+
+  struct
+  {
+    halp::data_port<"Rate of change (delta/time)",
+                    "Float. Units as per 'Output units'.",
+                    float>
+        out;
+  } outputs;
+
+  halp::setup setup;
+  void prepare(halp::setup info);
+
+  using tick = halp::tick;
+  void operator()(halp::tick t);
+
+  // derivative across the current window: (x_last - x_first) / sum(dt)
+  float delta_per(int unit) const;
+
+private:
+  // each sample pair contains value and dt
+  struct Sample
+  {
+    float  x;   // value
+    double dt;  // delta time since previous sample (seconds)
+  };
+
+  // ring buffer storage
+  std::vector<Sample> _buf;
+  const std::size_t _physCap = 1000000; // physical capacity (allocated size)
+  std::size_t _cap     = 0; // logical max samples 
+  std::size_t _head    = 0; // index of oldest in ring
+  std::size_t _size    = 0; // number of valid samples in window (<= _physCap)
+  double      _sumDt   = 0.0; // sum of dt for all samples except the oldest
+
+  // ---------- helpers ---------- //
+  // return a const reference to the nth newest sample (0 = newest)
+  const Sample& nth_newest_sample(std::size_t n) const;
+
+  // drop the oldest sample from the window
+  void drop_oldest_sample();
+
+  // push one new sample (x, dt) into the ring buffer
+  void push(float x, double dt);
+
+  // enforce sample window
+  void apply_window_policy();
+
+  // react to changes in parameters
+  void update_window_from_params();
+
+  // parameter watchers
+  halp::ParameterWatcher<int> sample_window_size;
+};
+
+} // namespace puara_gestures::objects


### PR DESCRIPTION
### Summary
Adds a flexible rate-of-change (derivative) calculator for real-time signals. The module supports two windowing strategies—fixed sample count or fixed time window—and provides multiple output unit options. In time window mode, the last known value is held constant when no new data arrives, ensuring continuous output. Diagnostic outputs expose the internal window state for debugging and analysis.

### Functionality
Input is:
- Signal (int or float) — input signal to analyze

Parameters are:
- Window mode (enum) — `SampleCount` (fixed number of samples) or `TimeWindow` (fixed duration)
- Sample count (int) — number of most recent samples to use (visible in `SampleCount` mode, minimum 2)
- Time window (float) — duration in seconds to use (visible in `TimeWindow` mode, 0.001–3600s)
- Output units (enum) — `per millisecond`, `per second`, `per minute`, or `per hour`

Outputs are:
- Rate (float) — computed rate of change in selected units
- Samples in window (int) — current number of samples in analysis window
- Window time span (float) — actual time span covered by window

### Implementation notes
- Sample count mode: Uses ring buffer to store N most recent samples
- Time window mode: Automatically adjusts window to requested time span; holds last value when data is sparse
- Rate calculation: Derivative computed as (newest − oldest) / sum(dt) with unit conversion
- Performance: O(1) operations with configurable buffer capacity (1M samples max)