### PR TITLE
Feature/scaler

### DIFF
--- a/3rdparty/extras/CMakeLists.txt
+++ b/3rdparty/extras/CMakeLists.txt
@@ -4,12 +4,8 @@ project(extras VERSION 1.0 LANGUAGES CXX)
 
 # Define the library sources
 add_library(extras
-  PeakDetector.cpp
-  PeakDetector.h
   helpers.cpp
   helpers.h
-  Normalizer.cpp
-  Normalizer.h
   EMA.h
   MinMaxScaler.cpp
   MinMaxScaler.h

--- a/3rdparty/extras/CMakeLists.txt
+++ b/3rdparty/extras/CMakeLists.txt
@@ -11,4 +11,8 @@ add_library(extras
   Normalizer.cpp
   Normalizer.h
   EMA.h
+  MinMaxScaler.cpp
+  MinMaxScaler.h
+  QuantileScaler.cpp
+  QuantileScaler.h
 )

--- a/3rdparty/extras/MinMaxScaler.cpp
+++ b/3rdparty/extras/MinMaxScaler.cpp
@@ -1,0 +1,156 @@
+/*
+ * MinMaxScaler.cpp
+ *
+ * Adapté de :
+ * Plaquette (c) 2015 Sofian Audry        :: info(@)sofianaudry(.)com
+ *            Thomas O Fredericks :: tof(@)t-o-f(.)info
+ *
+ * Adaptation par Luana Belinsky 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "MinMaxScaler.h"
+#include "EMA.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+// ---- Constructors -------------------------------------------------------- //
+
+MinMaxScaler::MinMaxScaler()
+  : _infinite(true)
+  , _tau_s(1.0)
+  , _minValue(0.0f)
+  , _maxValue(0.0f)
+  , _smoothedMinValue(0.5f)
+  , _smoothedMaxValue(0.5f)
+  , _value(0.5f)
+  , _n(0)
+{
+  init_states();
+}
+
+MinMaxScaler::MinMaxScaler(double timeWindowSeconds)
+  : _infinite(timeWindowSeconds <= 0.0)
+  , _tau_s(_infinite ? 1.0 : timeWindowSeconds)
+  , _minValue(0.0f)
+  , _maxValue(0.0f)
+  , _smoothedMinValue(0.5f)
+  , _smoothedMaxValue(0.5f)
+  , _value(0.5f)
+  , _n(0)
+{
+  init_states();
+}
+
+// ---- Time window control ------------------------------------------------- //
+
+void MinMaxScaler::timeWindow(double seconds)
+{
+  bool was_infinite = _infinite;
+
+  _infinite = (seconds <= 0.0);
+  _tau_s    = _infinite ? 1.0 : seconds;
+
+  // Switching from finite -> infinite: forget EMA state and reseed on next sample.
+  if (!was_infinite && _infinite) {
+    _n = 0;
+    init_states();
+  }
+}
+
+
+double MinMaxScaler::timeWindow() const
+{
+  return _infinite ? 0.0 : _tau_s;
+}
+
+bool MinMaxScaler::timeWindowIsInfinite() const
+{
+  return _infinite;
+}
+
+// ---- Reset --------------------------------------------------------------- //
+
+void MinMaxScaler::reset()
+{
+  _n = 0;
+  init_states();
+}
+
+// ---- Internal state init ------------------------------------------------- //
+
+void MinMaxScaler::init_states()
+{
+  // Start with no valid min/max; they will be initialized on first sample.
+  _minValue         =  std::numeric_limits<float>::max();
+  _maxValue         = -std::numeric_limits<float>::max();
+  _smoothedMinValue = 0.5f;
+  _smoothedMaxValue = 0.5f;
+  _value            = 0.5f;
+}
+
+// ---- Main entry ---------------------------------------------------------- //
+
+float MinMaxScaler::put(float x, double dt_seconds)
+{
+  // First sample: initialize everything from data.
+  if (_n == 0) {
+    _minValue         = x;
+    _maxValue         = x;
+    _smoothedMinValue = x;
+    _smoothedMaxValue = x;
+    _value            = 0.5f; // by convention when min == max
+    _n = 1;
+    return _value;
+  }
+
+  // Update raw min/max with new sample.
+  if (x < _minValue) _minValue = x;
+  if (x > _maxValue) _maxValue = x;
+
+  // Compute EMA alpha based on window and dt.
+  const float alpha = ema_alpha(_infinite, _tau_s, _n, dt_seconds);
+
+  // In finite-window mode, apply decay to min/max toward current sample.
+  if (!_infinite) {
+    ema_apply_update(_minValue, x, alpha);
+    ema_apply_update(_maxValue, x, alpha);
+  }
+
+  // Smooth out reported min/max values.
+  ema_apply_update(_smoothedMinValue, _minValue,  alpha);
+  ema_apply_update(_smoothedMaxValue, _maxValue,  alpha);
+
+  if (_n < std::numeric_limits<std::uint32_t>::max())
+    ++_n;
+
+  // Scale current sample into [0, 1] using smoothed min/max.
+  const float lo = _smoothedMinValue;
+  const float hi = _smoothedMaxValue;
+
+  if (hi <= lo) {
+    // Degenerate case: avoid division by zero; keep center at 0.5.
+    _value = 0.5f;
+  } else {
+    float t = (x - lo) / (hi - lo);
+    if (t < 0.0f)      t = 0.0f;
+    else if (t > 1.0f) t = 1.0f;
+    _value = t;
+  }
+
+  return _value;
+}

--- a/3rdparty/extras/MinMaxScaler.cpp
+++ b/3rdparty/extras/MinMaxScaler.cpp
@@ -28,7 +28,7 @@
 #include <cmath>
 #include <limits>
 
-// ---- Constructors -------------------------------------------------------- //
+// ---- Constructors ----- //
 
 MinMaxScaler::MinMaxScaler()
   : _infinite(true)
@@ -56,7 +56,7 @@ MinMaxScaler::MinMaxScaler(double timeWindowSeconds)
   init_states();
 }
 
-// ---- Time window control ------------------------------------------------- //
+// ---- Time window / decay control ------ //
 
 void MinMaxScaler::timeWindow(double seconds)
 {
@@ -72,7 +72,6 @@ void MinMaxScaler::timeWindow(double seconds)
   }
 }
 
-
 double MinMaxScaler::timeWindow() const
 {
   return _infinite ? 0.0 : _tau_s;
@@ -83,7 +82,7 @@ bool MinMaxScaler::timeWindowIsInfinite() const
   return _infinite;
 }
 
-// ---- Reset --------------------------------------------------------------- //
+// ---- Reset ----- //
 
 void MinMaxScaler::reset()
 {
@@ -91,19 +90,7 @@ void MinMaxScaler::reset()
   init_states();
 }
 
-// ---- Internal state init ------------------------------------------------- //
-
-void MinMaxScaler::init_states()
-{
-  // Start with no valid min/max; they will be initialized on first sample.
-  _minValue         =  std::numeric_limits<float>::max();
-  _maxValue         = -std::numeric_limits<float>::max();
-  _smoothedMinValue = 0.5f;
-  _smoothedMaxValue = 0.5f;
-  _value            = 0.5f;
-}
-
-// ---- Main entry ---------------------------------------------------------- //
+// ---- Main entry ------ //
 
 float MinMaxScaler::put(float x, double dt_seconds)
 {
@@ -153,4 +140,17 @@ float MinMaxScaler::put(float x, double dt_seconds)
   }
 
   return _value;
+}
+
+// ---- Helpers ----------------------------------------------------------------
+
+// Initialize the internal state
+void MinMaxScaler::init_states()
+{
+  // Start with no valid min/max; they will be initialized on first sample.
+  _minValue         =  std::numeric_limits<float>::max();
+  _maxValue         = -std::numeric_limits<float>::max();
+  _smoothedMinValue = 0.5f;
+  _smoothedMaxValue = 0.5f;
+  _value            = 0.5f;
 }

--- a/3rdparty/extras/MinMaxScaler.h
+++ b/3rdparty/extras/MinMaxScaler.h
@@ -40,9 +40,9 @@
 
 class MinMaxScaler {
 public:
-  /**
-   * Construct a scaler with infinite time window (no decay).
-   */
+  // ---- Constructors ----- //
+
+  /// Construct a scaler with infinite time window (no decay).
   MinMaxScaler();
 
   /**
@@ -53,7 +53,7 @@ public:
 
   virtual ~MinMaxScaler() {}
 
-  // ---- Time window control ---- //
+  // ---- Time window / decay control ------ //
 
   /// Sets the time window (seconds). <= 0.0 => infinite mode.
   virtual void timeWindow(double seconds);
@@ -64,29 +64,17 @@ public:
   /// Returns true if the time window is infinite (no decay).
   virtual bool timeWindowIsInfinite() const;
 
-  // ---- Reset ---- //
+  // ---- Reset ----- //
 
   /// Resets internal statistics and state.
   virtual void reset();
 
-  // ---- Inspectors ---- //
-
-  /// Returns the current (possibly decayed) minimum value.
-  float minValue() const { return _minValue; }
-
-  /// Returns the current (possibly decayed) maximum value.
-  float maxValue() const { return _maxValue; }
-
-  /// Returns the smoothed minimum value.
-  float smoothedMinValue() const { return _smoothedMinValue; }
-
-  /// Returns the smoothed maximum value.
-  float smoothedMaxValue() const { return _smoothedMaxValue; }
+  // ---- Inspectors ----- //
 
   /// Returns the last scaled output in [0, 1].
   float value() const { return _value; }
 
-  // ---- Main interface ---- //
+  // ---- Main entry ------ //
 
   /**
    * Pushes a new value and returns the scaled output in [0, 1].
@@ -98,7 +86,8 @@ public:
    */
   virtual float put(float x, double dt_seconds);
 
-protected:
+private:
+  /// Initialize the internal state
   void init_states();
 
   // Window configuration

--- a/3rdparty/extras/MinMaxScaler.h
+++ b/3rdparty/extras/MinMaxScaler.h
@@ -1,0 +1,123 @@
+/*
+ * MinMaxScaler.h
+ *
+ * Adapté de :
+ * Plaquette (c) 2015 Sofian Audry        :: info(@)sofianaudry(.)com
+ *            Thomas O Fredericks :: tof(@)t-o-f(.)info
+ *
+ * Adaptation par Luana Belinsky 2025
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef MIN_MAX_SCALER_H_
+#define MIN_MAX_SCALER_H_
+
+#include <cstdint>
+
+/*
+ * Adaptive min-max scaler: rescales a stream of values into [0, 1]
+ * using running estimates of minimum and maximum.
+ *
+ * The class supports:
+ *  - Infinite mode (hard running min/max, no decay)
+ *  - Finite time window (EMA-based decay of min/max)
+ *
+ * Smoothed versions of min/max are tracked to avoid abrupt jumps
+ * when extremes change.
+ */
+
+class MinMaxScaler {
+public:
+  /**
+   * Construct a scaler with infinite time window (no decay).
+   */
+  MinMaxScaler();
+
+  /**
+   * Construct a scaler with a given time window (in seconds).
+   * A time window <= 0.0 selects infinite mode.
+   */
+  MinMaxScaler(double timeWindowSeconds);
+
+  virtual ~MinMaxScaler() {}
+
+  // ---- Time window control ---- //
+
+  /// Sets the time window (seconds). <= 0.0 => infinite mode.
+  virtual void timeWindow(double seconds);
+
+  /// Returns the time window (seconds). 0.0 => infinite mode.
+  virtual double timeWindow() const;
+
+  /// Returns true if the time window is infinite (no decay).
+  virtual bool timeWindowIsInfinite() const;
+
+  // ---- Reset ---- //
+
+  /// Resets internal statistics and state.
+  virtual void reset();
+
+  // ---- Inspectors ---- //
+
+  /// Returns the current (possibly decayed) minimum value.
+  float minValue() const { return _minValue; }
+
+  /// Returns the current (possibly decayed) maximum value.
+  float maxValue() const { return _maxValue; }
+
+  /// Returns the smoothed minimum value.
+  float smoothedMinValue() const { return _smoothedMinValue; }
+
+  /// Returns the smoothed maximum value.
+  float smoothedMaxValue() const { return _smoothedMaxValue; }
+
+  /// Returns the last scaled output in [0, 1].
+  float value() const { return _value; }
+
+  // ---- Main interface ---- //
+
+  /**
+   * Pushes a new value and returns the scaled output in [0, 1].
+   *
+   * @param x          input value
+   * @param dt_seconds elapsed time since the previous sample (seconds).
+   *                   If dt_seconds <= 0 in finite-window mode, the
+   *                   update falls back to immediate adjustment.
+   */
+  virtual float put(float x, double dt_seconds);
+
+protected:
+  void init_states();
+
+  // Window configuration
+  bool   _infinite;
+  double _tau_s;
+
+  // Min/max estimates
+  float _minValue;
+  float _maxValue;
+
+  // Smoothed min/max
+  float _smoothedMinValue;
+  float _smoothedMaxValue;
+
+  // Last output value in [0, 1]
+  float _value;
+
+  // Sample counter
+  std::uint32_t _n;
+};
+
+#endif // MIN_MAX_SCALER_H_

--- a/3rdparty/extras/QuantileScaler.cpp
+++ b/3rdparty/extras/QuantileScaler.cpp
@@ -1,0 +1,231 @@
+/*
+ * QuantileScaler.cpp
+ *
+ * (c) 2025 Sofian Audry        :: info(@)sofianaudry(.)com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Adaptive quantile-based scaler using Robbins–Monro updates.
+ */
+
+#include "QuantileScaler.h"
+#include "EMA.h"
+#include "helpers.h"  
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+// Minimum quantile level to avoid ill-defined zero quantile.
+static constexpr float kMinimumQuantileLevel = 1e-4f;
+static constexpr float kMaximumQuantileLevel = 0.5f;
+
+// Number of standard deviations to cover the full range.
+static constexpr float kStddevToRange = 6.0f;
+
+// ---- Span / quantile mapping helpers ------------------------------------ //
+
+float QuantileScaler::lowQuantileLevelToSpan(float level)
+{
+  // Clamp level into allowed range.
+  level = std::clamp(level, kMinimumQuantileLevel, kMaximumQuantileLevel);
+  // For symmetric coverage, span ≈ 1 - 2*lowLevel.
+  float span = 1.0f - 2.0f * level;
+  return std::clamp(span, 0.0f, 1.0f);
+}
+
+float QuantileScaler::spanToLowQuantileLevel(float span)
+{
+  // Clamp span into [0, 1].
+  span = std::clamp(span, 0.0f, 1.0f);
+  // Inverse of span ≈ 1 - 2*lowLevel -> lowLevel ≈ (1 - span)/2.
+  float level = 0.5f * (1.0f - span);
+  // Clamp into [kMinimumQuantileLevel, kMaximumQuantileLevel].
+  return std::clamp(level, kMinimumQuantileLevel, kMaximumQuantileLevel);
+}
+
+// ---- Constructors -------------------------------------------------------- //
+
+QuantileScaler::QuantileScaler()
+  : _infinite(true)
+  , _tau_s(1.0)
+  , _lowQuantileLevel(spanToLowQuantileLevel(kDefaultSpan))
+  , _lowQuantile(0.0f)
+  , _highQuantile(0.0f)
+  , _stddev(0.0f)
+  , _value(0.5f)
+  , _n(0)
+{
+  init_states();
+}
+
+QuantileScaler::QuantileScaler(double timeWindowSeconds, float span)
+  : _infinite(timeWindowSeconds <= 0.0)
+  , _tau_s(_infinite ? 1.0 : timeWindowSeconds)
+  , _lowQuantileLevel(spanToLowQuantileLevel(span))
+  , _lowQuantile(0.0f)
+  , _highQuantile(0.0f)
+  , _stddev(0.0f)
+  , _value(0.5f)
+  , _n(0)
+{
+  init_states();
+}
+
+// ---- Time window control ------------------------------------------------- //
+
+void QuantileScaler::timeWindow(double seconds)
+{
+  bool was_infinite = _infinite;
+
+  _infinite = (seconds <= 0.0);
+  _tau_s    = _infinite ? 1.0 : seconds;
+
+  // Switching from finite -> infinite: drop old EMA state and reseed on next sample.
+  if (!was_infinite && _infinite) {
+    _n = 0;
+    init_states();
+  }
+}
+
+
+double QuantileScaler::timeWindow() const
+{
+  return _infinite ? 0.0 : _tau_s;
+}
+
+bool QuantileScaler::timeWindowIsInfinite() const
+{
+  return _infinite;
+}
+
+// ---- Reset / init -------------------------------------------------------- //
+
+void QuantileScaler::reset()
+{
+  _n = 0;
+  init_states();
+}
+
+void QuantileScaler::init_states()
+{
+  _lowQuantile  =  std::numeric_limits<float>::max();
+  _highQuantile = -std::numeric_limits<float>::max();
+  _stddev       = 0.0f;
+  _value        = 0.5f;
+}
+
+// ---- Span / quantiles API ------------------------------------------------ //
+
+void QuantileScaler::span(float span)
+{
+  _lowQuantileLevel = spanToLowQuantileLevel(span);
+}
+
+float QuantileScaler::span() const
+{
+  return lowQuantileLevelToSpan(_lowQuantileLevel);
+}
+
+void QuantileScaler::lowQuantileLevel(float level)
+{
+  level = std::clamp(level, 0.0f, kMaximumQuantileLevel);
+  _lowQuantileLevel = std::clamp(level, kMinimumQuantileLevel, kMaximumQuantileLevel);
+}
+
+void QuantileScaler::highQuantileLevel(float level)
+{
+  // low + high = 1 for symmetric coverage.
+  lowQuantileLevel(1.0f - level);
+}
+
+// ---- Main entry ---------------------------------------------------------- //
+
+float QuantileScaler::put(float x, double dt_seconds)
+{
+  // First sample: initialize quantiles and stddev.
+  if (_n == 0) {
+    _lowQuantile  = x;
+    _highQuantile = x;
+    _stddev       = 0.0f;
+    _value        = 0.5f;
+    _n = 1;
+    return _value;
+  }
+
+  // Compute EMA alpha based on window and dt.
+  const float alpha = ema_alpha(_infinite, _tau_s, _n, dt_seconds);
+
+  // Mid-quantile and deviation for stddev estimate.
+  const float midQuantile = 0.5f * (_lowQuantile + _highQuantile);
+  const float deviation   = std::fabs(x - midQuantile);
+
+  if (_n == 1 && _stddev == 0.0f) {
+    _stddev = deviation;
+  } else {
+    ema_apply_update(_stddev, deviation, alpha);
+  }
+
+  // Compute Robbins–Monro step size scaled by stddev.
+  float eta = alpha * kStddevToRange * _stddev;
+  if (eta < 0.0f) eta = 0.0f;
+
+  const float etaLevel = eta * _lowQuantileLevel;
+
+  // Update quantiles depending on where x lies.
+  if (x <= _lowQuantile) {
+    // Smaller than both quantiles.
+    _lowQuantile  -= eta - etaLevel; // decrease
+    _highQuantile -= etaLevel;       // decrease
+    // Prevent overshooting.
+    _lowQuantile  = std::max(_lowQuantile,  x);
+    _highQuantile = std::max(_highQuantile, x);
+  }
+  else if (x <= _highQuantile) {
+    // Between low and high.
+    _lowQuantile  += etaLevel;       // increase
+    _highQuantile -= etaLevel;       // decrease
+    // Prevent overshooting.
+    _lowQuantile  = std::min(_lowQuantile,  x);
+    _highQuantile = std::max(_highQuantile, x);
+  }
+  else {
+    // Larger than both quantiles.
+    _lowQuantile  += etaLevel;        // increase
+    _highQuantile += eta - etaLevel;  // increase
+    // Prevent overshooting.
+    _lowQuantile  = std::min(_lowQuantile,  x);
+    _highQuantile = std::min(_highQuantile, x);
+  }
+
+  // Optional decay of quantiles toward their mid-point in finite-window mode.
+  if (!_infinite) {
+    ema_apply_update(_lowQuantile,  midQuantile, alpha);
+    ema_apply_update(_highQuantile, midQuantile, alpha);
+  }
+
+  // Clamp quantiles to avoid inversions.
+  if (_lowQuantile > _highQuantile) {
+    const float mid = 0.5f * (_lowQuantile + _highQuantile);
+    _lowQuantile  = mid;
+    _highQuantile = mid;
+  }
+
+  if (_n < std::numeric_limits<std::uint32_t>::max())
+    ++_n;
+
+  // Compute rescaled value using shared map helper into [0, 1].
+  _value = helpers::map(x, _lowQuantile, _highQuantile, 0.0f, 1.0f);
+  return _value;
+}

--- a/3rdparty/extras/QuantileScaler.h
+++ b/3rdparty/extras/QuantileScaler.h
@@ -1,0 +1,142 @@
+/*
+ * QuantileScaler.h
+ *
+ * (c) 2025 Sofian Audry        :: info(@)sofianaudry(.)com
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Adaptive quantile-based scaler using Robbins–Monro updates.
+ */
+
+#ifndef QUANTILE_SCALER_H_
+#define QUANTILE_SCALER_H_
+
+#include <cstdint>
+
+/*
+ * Regularizes a signal into [0, 1] using adaptive quantile tracking.
+ *
+ * The scaler tracks low and high quantiles of the input distribution
+ * using Robbins–Monro stochastic updates, and maps the input into [0, 1]
+ * based on those quantiles. This makes it robust to outliers compared
+ * to a simple min–max scaler.
+ *
+ * The class supports:
+ *  - Infinite mode (no decay of quantiles)
+ *  - Finite time window (EMA-based decay)
+ */
+
+class QuantileScaler {
+public:
+  // Default span (corresponds to percentage coverage of values in [0, 1]).
+  static constexpr float kDefaultSpan = 0.99f;
+
+  QuantileScaler();
+  QuantileScaler(double timeWindowSeconds, float span = kDefaultSpan);
+
+  virtual ~QuantileScaler() {}
+
+  // ---- Time window control ---- //
+
+  /// Sets the adaptation time window (in seconds). <= 0.0 => infinite mode.
+  virtual void   timeWindow(double seconds);
+
+  /// Returns the current time window (in seconds). 0.0 => infinite mode.
+  virtual double timeWindow() const;
+
+  /// Returns true if time window is infinite.
+  virtual bool   timeWindowIsInfinite() const;
+
+  // ---- Reset ---- //
+
+  /// Resets the filter state.
+  virtual void reset();
+
+  // ---- Span / quantiles ---- //
+
+  /// Sets the span (in [0, 1]) of the central mass to be covered.
+  /// For example, span = 0.99 covers approximately 99% of values.
+  virtual void span(float span);
+
+  /// Returns the current span.
+  virtual float span() const;
+
+  /// Sets the low quantile level (in [0, 0.5]).
+  virtual void lowQuantileLevel(float level);
+
+  /// Returns the current low quantile level.
+  virtual float lowQuantileLevel() const { return _lowQuantileLevel; }
+
+  /// Sets the high quantile level (in [0.5, 1]).
+  virtual void highQuantileLevel(float level);
+
+  /// Returns the current high quantile level.
+  virtual float highQuantileLevel() const { return (1.0f - _lowQuantileLevel); }
+
+  // ---- Inspectors ---- //
+
+  /// Returns the current low quantile estimate.
+  float lowQuantile()  const { return _lowQuantile; }
+
+  /// Returns the current high quantile estimate.
+  float highQuantile() const { return _highQuantile; }
+
+  /// Returns the current stddev proxy used to scale the quantile step size.
+  float stddev() const { return _stddev; }
+
+  /// Returns the last scaled output in [0, 1].
+  float value() const { return _value; }
+
+  // ---- Main interface ---- //
+
+  /**
+   * Pushes a new value and returns the scaled output.
+   *
+   * @param x          input value
+   * @param dt_seconds elapsed time since the previous sample (seconds).
+   *                   If dt_seconds <= 0 in finite-window mode, the
+   *                   update falls back to immediate adjustment.
+   */
+  virtual float put(float x, double dt_seconds);
+
+protected:
+  void  init_states();
+
+  // Mapping between span (central mass) and low quantile level.
+  static float lowQuantileLevelToSpan(float level);
+  static float spanToLowQuantileLevel(float span);
+
+protected:
+  // Time window (in seconds).
+  bool   _infinite;
+  double _tau_s;
+
+  // Low quantile level (in [0, 0.5]).
+  float _lowQuantileLevel;
+
+  // Quantile estimators.
+  float _lowQuantile;   // q_low
+  float _highQuantile;  // q_high
+
+  // Stddev estimator (based on deviation from mid-quantile).
+  float _stddev;
+
+  // Last scaled value in [0, 1].
+  float _value;
+
+  // Number of samples since last reset.
+  std::uint32_t _n;
+};
+
+#endif // QUANTILE_SCALER_H_

--- a/3rdparty/extras/helpers.cpp
+++ b/3rdparty/extras/helpers.cpp
@@ -1,10 +1,22 @@
 
 #include "helpers.h"
+#include <algorithm>
 
-namespace helpers
+namespace helpers {
+float map(float value,
+                 float min1, float max1,
+                 float min2, float max2)
 {
-float map(float value, float min1, float max1, float min2, float max2)
-{
-  return (value - min1) / (max1 - min1) * (max2 - min2) + min2;
+    if (max1 == min1)
+        return min2;   // degenerate input range
+
+    float t = (value - min1) / (max1 - min1);
+    float out = min2 + t * (max2 - min2);
+
+    // Clamp to output bounds
+    if (min2 < max2)
+        return std::clamp(out, min2, max2);
+    else
+        return std::clamp(out, max2, min2); // handle reversed ranges
 }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,11 @@ target_sources(score_addon_puara
   3rdparty/extras/helpers.h
   3rdparty/extras/helpers.cpp
   3rdparty/extras/EMA.h
+  3rdparty/extras/MinMaxScaler.h
+  3rdparty/extras/MinMaxScaler.cpp
+  3rdparty/extras/QuantileScaler.h
+  3rdparty/extras/QuantileScaler.cpp
+
   Puara/vamp_algorithms.hpp
   Puara/statistics_algorithms.hpp
 )
@@ -128,6 +133,16 @@ avnd_score_plugin_add(
     Puara/Normalization.cpp
   TARGET puara_normalization
   MAIN_CLASS Normalization
+  NAMESPACE puara_gestures::objects
+)
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/Scaler.hpp
+    Puara/Scaler.cpp
+  TARGET puara_scaler
+  MAIN_CLASS Scaler
   NAMESPACE puara_gestures::objects
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,8 +60,6 @@ target_sources(score_addon_puara
   3rdparty/extras/PeakDetector.cpp
   3rdparty/extras/Normalizer.h
   3rdparty/extras/Normalizer.cpp
-  3rdparty/extras/Normalizer.h
-  3rdparty/extras/Normalizer.cpp
   3rdparty/extras/helpers.h
   3rdparty/extras/helpers.cpp
   3rdparty/extras/EMA.h
@@ -132,17 +130,6 @@ avnd_score_plugin_add(
   MAIN_CLASS Normalization
   NAMESPACE puara_gestures::objects
 )
-
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/Smoother.hpp
-    Puara/Smoother.cpp
-  TARGET smoother
-  MAIN_CLASS Smoother
-  NAMESPACE puara_gestures::objects
-)
-
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,16 +129,6 @@ avnd_score_plugin_add(
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara
   SOURCES
-    Puara/Normalization.hpp
-    Puara/Normalization.cpp
-  TARGET puara_normalization
-  MAIN_CLASS Normalization
-  NAMESPACE puara_gestures::objects
-)
-
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
     Puara/Scaler.hpp
     Puara/Scaler.cpp
   TARGET puara_scaler

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ target_sources(score_addon_puara
   3rdparty/extras/MinMaxScaler.cpp
   3rdparty/extras/QuantileScaler.h
   3rdparty/extras/QuantileScaler.cpp
-
+ 
   Puara/vamp_algorithms.hpp
   Puara/statistics_algorithms.hpp
 )
@@ -135,6 +135,27 @@ avnd_score_plugin_add(
   MAIN_CLASS Scaler
   NAMESPACE puara_gestures::objects
 )
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/Normalization.hpp
+    Puara/Normalization.cpp
+  TARGET puara_normalization
+  MAIN_CLASS Normalization
+  NAMESPACE puara_gestures::objects
+)
+
+avnd_score_plugin_add(
+  BASE_TARGET score_addon_puara
+  SOURCES
+    Puara/Smoother.hpp
+    Puara/Smoother.cpp
+  TARGET smoother
+  MAIN_CLASS Smoother
+  NAMESPACE puara_gestures::objects
+)
+
 
 avnd_score_plugin_add(
   BASE_TARGET score_addon_puara

--- a/Puara/Scaler.cpp
+++ b/Puara/Scaler.cpp
@@ -1,0 +1,107 @@
+#include "Scaler.hpp"
+
+#include <limits>
+#include <cmath>
+#include <algorithm>
+
+namespace puara_gestures::objects
+{
+
+void Scaler::prepare(halp::setup info)
+{
+  setup = info;
+
+  // Initialize both scalers with default config.
+  minmax   = MinMaxScaler();   // infinite window by default
+  quantile = QuantileScaler(); // infinite window by default
+
+  // Initial time window setup from UI.
+  const bool  infinite = inputs.infinite_time_window;
+  const float tw       = inputs.time_window;
+
+  const double tw_seconds = infinite ? 0.0
+                                     : static_cast<double>(tw);
+
+  minmax.timeWindow(tw_seconds);
+  quantile.timeWindow(tw_seconds);
+
+  // Initial span for quantile mode.
+  quantile.span(inputs.span);
+
+  // Initial mode from UI.
+  Mode mode_value = inputs.mode.value; 
+  current_mode    = mode_value;
+
+  // Prime watchers with initial values
+  mode_watcher.changed(mode_value);
+  infinite_watcher.changed(infinite);
+  time_window_watcher.changed(tw);
+  span_watcher.changed(inputs.span);
+}
+
+void Scaler::operator()(halp::tick t)
+{
+  // --- compute dt (seconds) from tick ---
+  float dt = 0.0f;
+  if (setup.rate > 0.0f) {
+    const float maybe_dt =
+        static_cast<float>(t.frames) / static_cast<float>(setup.rate);
+    if (maybe_dt > 0.0f && maybe_dt < 0.1f)  // guard: 0 < dt < 100 ms
+      dt = maybe_dt;
+  }
+
+  // --- handle live parameter changes with watchers ---
+
+  // Mode change (enum_t -> Mode).
+  Mode mode_value = static_cast<Mode>(inputs.mode);
+  if (mode_watcher.changed(mode_value)) {
+    if (mode_value != current_mode) {
+      current_mode = mode_value;
+
+      // Reset the newly activated scaler so it does not inherit stale stats.
+      if (current_mode == Mode::Min_max)
+        minmax.reset();
+      else
+        quantile.reset();
+    }
+  }
+
+  // Time window & infinite flag: shared between both scalers.
+  const bool  infinite = inputs.infinite_time_window;
+  const float tw       = inputs.time_window;
+
+  if (infinite_watcher.changed(infinite) || time_window_watcher.changed(tw)) {
+    const double tw_seconds = infinite ? 0.0
+                                       : static_cast<double>(tw);
+    minmax.timeWindow(tw_seconds);
+    quantile.timeWindow(tw_seconds);
+  }
+
+  // Quantile span: only affects quantile scaler, but we can watch it here.
+  const float span = inputs.span;
+  if (span_watcher.changed(span)) {
+    quantile.span(span);
+  }
+
+  // --- process current sample ---
+  const float x = inputs.scaling_signal;
+
+  float scaled01 = 0.0f;
+
+  if (current_mode == Mode::Min_max) {
+    scaled01 = minmax.put(x, static_cast<double>(dt));      // expected ∈ [0, 1]
+  } else {
+    scaled01 = quantile.put(x, static_cast<double>(dt));    // expected ∈ [0, 1]
+  }
+
+  // Map scaled value into chosen output range.
+  const float y = helpers::map(
+      scaled01,
+      0.0f, 1.0f,
+      inputs.out_low,
+      inputs.out_high);
+
+  outputs.out = y;
+}
+
+} // namespace puara_gestures::objects

--- a/Puara/Scaler.hpp
+++ b/Puara/Scaler.hpp
@@ -23,9 +23,10 @@ public:
   halp_meta(category, "Analysis/Data")
   halp_meta(c_name, "Scaler")
   halp_meta(author, "Luana Belinsky (adapted from Sofian Audry’s Plaquette)")
-  halp_meta(description,
-    "Adaptive scaler with min-max or quantile-based modes. "
-    "Maps input into a chosen output range using a time window.")
+  halp_meta(
+      description,
+      "Adaptive scaler with min-max or quantile-based modes. "
+      "Maps input into a chosen output range using a time window.")
   halp_meta(manual_url, "https://plaquette.org/MinMaxScaler.html")
   halp_meta(uuid, "0c1f93f9-de5b-4535-8f70-c646c05dcb08")
 
@@ -45,31 +46,37 @@ public:
 
     halp::enum_t<Mode, "Mode"> mode{Mode::Min_max};
 
-    halp::spinbox_f32<"Time window (s)",
-                      halp::range{0.01, 360.0, 1.0}>
+    halp::spinbox_f32<
+        "Time window (s)",
+        halp::range{0.01, 360.0, 1.0}>
         time_window;
 
-    halp::toggle<"Infinite time window">
+    halp::toggle<
+        "Infinite time window">
         infinite_time_window{false};
 
-    halp::spinbox_f32<"Output low",
-                      halp::range{-5.0, 5.0, 0.0}>
+    halp::spinbox_f32<
+        "Output low",
+        halp::range{-5.0, 5.0, 0.0}>
         out_low;
 
-    halp::spinbox_f32<"Output high",
-                      halp::range{-5.0, 5.0, 1.0}>
+    halp::spinbox_f32<
+        "Output high",
+        halp::range{-5.0, 5.0, 1.0}>
         out_high;
 
-    halp::knob_f32<"Span",
-                   halp::range{0.50, 1.00, 0.99}>
+    halp::knob_f32<
+        "Span",
+        halp::range{0.50, 1.00, 0.99}>
         span;
   } inputs;
 
   struct
   {
-    halp::data_port<"Scaled",
-                    "Signal scaled into the chosen output range.",
-                    float>
+    halp::data_port<
+        "Scaled",
+        "Signal scaled into the chosen output range.",
+        float>
         out;
   } outputs;
 

--- a/Puara/Scaler.hpp
+++ b/Puara/Scaler.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "3rdparty/extras/MinMaxScaler.h"
+#include "3rdparty/extras/QuantileScaler.h"
+#include "3rdparty/extras/helpers.h"
+
+#include <limits>
+#include <cstdint>
+
+#include <halp/audio.hpp>
+#include <halp/controls.hpp>
+#include <halp/meta.hpp>
+#include <puara/gestures.h>
+#include "halp_utils.hpp"
+
+namespace puara_gestures::objects
+{
+
+class Scaler
+{
+public:
+  halp_meta(name, "Scaler")
+  halp_meta(category, "Analysis/Data")
+  halp_meta(c_name, "Scaler")
+  halp_meta(author, "Luana Belinsky (adapted from Sofian Audry’s Plaquette)")
+  halp_meta(description,
+    "Adaptive scaler with min-max or quantile-based modes. "
+    "Maps input into a chosen output range using a time window.")
+  halp_meta(manual_url, "https://plaquette.org/MinMaxScaler.html")
+  halp_meta(uuid, "0c1f93f9-de5b-4535-8f70-c646c05dcb08")
+
+  enum class Mode
+  {
+    Min_max,
+    Quantile
+  };
+
+  struct
+  {
+    halp::data_port<
+        "Signal",
+        "Input signal to scale",
+        float>
+        scaling_signal;
+
+    halp::enum_t<Mode, "Mode"> mode{Mode::Min_max};
+
+    halp::spinbox_f32<"Time window (s)",
+                      halp::range{0.01, 360.0, 1.0}>
+        time_window;
+
+    halp::toggle<"Infinite time window">
+        infinite_time_window{false};
+
+    halp::spinbox_f32<"Output low",
+                      halp::range{-5.0, 5.0, 0.0}>
+        out_low;
+
+    halp::spinbox_f32<"Output high",
+                      halp::range{-5.0, 5.0, 1.0}>
+        out_high;
+
+    halp::knob_f32<"Span",
+                   halp::range{0.50, 1.00, 0.99}>
+        span;
+  } inputs;
+
+  struct
+  {
+    halp::data_port<"Scaled",
+                    "Signal scaled into the chosen output range.",
+                    float>
+        out;
+  } outputs;
+
+  halp::setup setup;
+  void prepare(halp::setup info);
+
+  using tick = halp::tick;
+  void operator()(halp::tick t);
+
+private:
+  // Internal scaling engines.
+  MinMaxScaler   minmax;
+  QuantileScaler quantile;
+
+  // Currently active mode.
+  Mode current_mode{Mode::Min_max};
+
+  // Parameter watchers.
+  halp::ParameterWatcher<Mode>  mode_watcher;
+  halp::ParameterWatcher<bool>  infinite_watcher;
+  halp::ParameterWatcher<float> time_window_watcher;
+  halp::ParameterWatcher<float> span_watcher;
+};
+
+} // namespace puara_gestures::objects


### PR DESCRIPTION
### Summary
Adds an adaptive scaling utility for real-time signals with two operating modes: Min-Max or Quantile-based scaling. The module continuously tracks either absolute minimum/maximum values (Min-Max mode) or statistical quantiles (Quantile mode) to rescale input into a configurable output range. Both modes support either cumulative tracking (infinite window) or time-windowed adaptation (EMA decay).

Adapted from Sofian Audry's [Plaquette implementation](https://sofapirate.github.io/Plaquette/MinMaxScaler.html) for Min-Max scaling and RobustScaler for quantile-based scaling.

### Functionality
Inputs are : 
- Signal (int or float)

Parameters are:
- Mode (enum) — Min_max (absolute range) or Quantile (statistical range)
- Time window (s) (float) — EMA window for adaptation; dt inferred per tick; 0 / toggle → infinite
- Infinite time window (bool) — cumulative mode (no decay)
- Output low (float) — minimum value of output range
- Output high (float) — maximum value of output range
- Span (float) — Quantile mode only: coverage percentage of distribution (0.50-1.00)

Outputs are:
- Scaled (float) — signal scaled into chosen output range

Modes Explained
Min-Max Mode:
- Tracks absolute minimum and maximum values
- Maps everything between min - max to output range
- Sensitive to outliers — a single extreme value compresses everything else

Quantile Mode:
- Tracks low and high quantiles (e.g., 1st and 99th percentiles)
- Span controls what percentage of typical values to track (ex : 1.00 = full min-max (0th-100th percentile), 0.50 = middle 50% (25th-75th percentile, interquartile range))
- Ignores extreme values outside the span for robust scaling

### Implementation notes
Uses MinMaxScaler and QuantileScaler custom classes stored in 3rdparty/extras (to be reused in Respiration and EDA processes)