### PR TITLE
cmake: converge to generic find_package(Avendish) + avnd_addon_* setup

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -2,28 +2,14 @@ name: Build
 on:
   pull_request:
   push:
-    branches:
-      - master
-      - main
-      - dev
-      - develop
-    tags:
-      - v*
+    branches: [master, main, dev, develop]
+    tags: ['v*']
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  dev:
-    uses: ossia/actions/.github/workflows/builds-dev.yml@master
-    secrets: inherit
-  sdk:
-    uses: ossia/actions/.github/workflows/builds-sdk.yml@master
-    secrets: inherit
-  jit:
-    uses: ossia/actions/.github/workflows/jit.yml@master
-    secrets: inherit
-  release:
-    uses: ossia/actions/.github/workflows/release.yml@master
+  ci:
+    uses: ossia/actions/.github/workflows/score-addon.yml@master
     secrets: inherit

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -10,6 +10,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci:
+  # Build + package the score add-on (dev / SDK / JIT / release tracks).
+  score:
     uses: ossia/actions/.github/workflows/score-addon.yml@master
     secrets: inherit
+
+  # Build the same object(s) standalone, one artifact per back-end.
+  # CATEGORY object (default; all avnd_addon_object calls are message/data
+  # objects with no CATEGORY/BACKENDS): pd / max / python / touchdesigner /
+  # godot / wasm.
+  standalone:
+    uses: ossia/actions/.github/workflows/avnd-addon.yml@master
+    secrets: inherit
+    with:
+      pd: true
+      max: true
+      python: true
+      touchdesigner: true
+      godot: true
+      wasm: true

--- a/.github/workflows/portability.yml
+++ b/.github/workflows/portability.yml
@@ -1,0 +1,19 @@
+name: Portability
+
+on:
+  pull_request:
+  push:
+    branches: [main, master]
+
+concurrency:
+  group: ${{ github.workflow }}-portability-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    uses: ossia/actions/.github/workflows/avnd-portability.yml@master
+    secrets: inherit
+    with:
+      # iOS off: Xcode multi-config plumbing fails and iOS isn't a meaningful
+      # target. The other 20 lanes cover the portability surface.
+      ios: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,19 @@
 cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
-if(NOT TARGET score_lib_base)
-  include(ScoreExternalAddon)
-endif()
-
-if(NOT TARGET score_plugin_avnd)
-  return()
-endif()
-
 project(score_addon_puara LANGUAGES CXX)
+
+# Use the Avendish the host (ossia score) provides; otherwise fetch it.
+find_package(Avendish QUIET)
+if(NOT Avendish_FOUND)
+  include(FetchContent)
+  FetchContent_Declare(
+    Avendish
+    GIT_REPOSITORY "https://github.com/celtera/avendish"
+    GIT_TAG main)
+  FetchContent_Populate(Avendish)
+  list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
+  find_package(Avendish REQUIRED)
+endif()
 
 set(PUARA_GESTURES_ENABLE_TESTING OFF)
 set(PUARA_GESTURES_ENABLE_STANDALONE OFF)
@@ -21,9 +26,7 @@ add_subdirectory(3rdparty/BioData SYSTEM)
 add_subdirectory(3rdparty/extras SYSTEM)
 
 
-avnd_score_plugin_init(
-  BASE_TARGET score_addon_puara
-)
+avnd_addon_init(NAME score_addon_puara)
 
 
 target_sources(score_addon_puara
@@ -78,266 +81,236 @@ target_include_directories(score_addon_puara
 )
 target_link_libraries(score_addon_puara PUBLIC BioData)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/GestureRecognizer.hpp
-    Puara/GestureRecognizer.cpp
-  TARGET puara_gesture
-  MAIN_CLASS GestureRecognizer
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_gesture
+  CLASS GestureRecognizer
   NAMESPACE puara_gestures::objects
-)
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/PowerBandAvnd.hpp
-    Puara/PowerBandAvnd.cpp
-  TARGET puara_powerband
-  MAIN_CLASS PowerBandAvnd
+Puara/GestureRecognizer.hpp
+    Puara/GestureRecognizer.cpp)
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_powerband
+  CLASS PowerBandAvnd
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/PowerBandAvnd.hpp
+    Puara/PowerBandAvnd.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/ERPAvnd.hpp
-    Puara/ERPAvnd.cpp
-  TARGET puara_erp_avnd
-  MAIN_CLASS ERPAvnd
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_erp_avnd
+  CLASS ERPAvnd
   NAMESPACE puara_gestures::objects
-)
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/CorrelationAvnd.hpp
-    Puara/CorrelationAvnd.cpp
-  TARGET puara_correlation_avnd
-  MAIN_CLASS CorrelationAvnd
+Puara/ERPAvnd.hpp
+    Puara/ERPAvnd.cpp)
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_correlation_avnd
+  CLASS CorrelationAvnd
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/CorrelationAvnd.hpp
+    Puara/CorrelationAvnd.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/EdaRtFeatures.hpp
-    Puara/EdaRtFeatures.cpp
-  TARGET puara_eda
-  MAIN_CLASS EdaRtFeatures
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_eda
+  CLASS EdaRtFeatures
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/EdaRtFeatures.hpp
+    Puara/EdaRtFeatures.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/BioDataHeart.hpp
-    Puara/BioDataHeart.cpp
-  TARGET puara_heart
-  MAIN_CLASS BioData_Heart
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_heart
+  CLASS BioData_Heart
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/BioDataHeart.hpp
+    Puara/BioDataHeart.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/Scaler.hpp
-    Puara/Scaler.cpp
-  TARGET puara_scaler
-  MAIN_CLASS Scaler
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_scaler
+  CLASS Scaler
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/Scaler.hpp
+    Puara/Scaler.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/Normalization.hpp
-    Puara/Normalization.cpp
-  TARGET puara_normalization
-  MAIN_CLASS Normalization
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_normalization
+  CLASS Normalization
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/Normalization.hpp
+    Puara/Normalization.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/Smoother.hpp
-    Puara/Smoother.cpp
-  TARGET smoother
-  MAIN_CLASS Smoother
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME smoother
+  CLASS Smoother
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/Smoother.hpp
+    Puara/Smoother.cpp)
 
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/ButtonAvnd.hpp
-    Puara/ButtonAvnd.cpp
-  TARGET puara_button_avnd
-  MAIN_CLASS ButtonAvnd
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_button_avnd
+  CLASS ButtonAvnd
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/ButtonAvnd.hpp
+    Puara/ButtonAvnd.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/WalkerAvnd.hpp
-    Puara/WalkerAvnd.cpp
-  TARGET walker_avnd
-  MAIN_CLASS WalkerAvnd
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME walker_avnd
+  CLASS WalkerAvnd
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/WalkerAvnd.hpp
+    Puara/WalkerAvnd.cpp)
 
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/BioDataSkinConductance.hpp
-    Puara/BioDataSkinConductance.cpp
-  TARGET puara_skin_conductance
-  MAIN_CLASS BioData_Skin_Conductance
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_skin_conductance
+  CLASS BioData_Skin_Conductance
   NAMESPACE puara_gestures::objects
-)
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/ClusteringAvnd.hpp
-    Puara/ClusteringAvnd.cpp
-  TARGET ClusteringAvnd
-  MAIN_CLASS ClusteringAvnd
+Puara/BioDataSkinConductance.hpp
+    Puara/BioDataSkinConductance.cpp)
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME ClusteringAvnd
+  CLASS ClusteringAvnd
   NAMESPACE puara_gestures::objects
-)
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/VAMPAvnd.hpp
-    Puara/VAMPAvnd.cpp
-  TARGET vamp_avnd
-  MAIN_CLASS VAMPAvnd
+Puara/ClusteringAvnd.hpp
+    Puara/ClusteringAvnd.cpp)
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME vamp_avnd
+  CLASS VAMPAvnd
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/VAMPAvnd.hpp
+    Puara/VAMPAvnd.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_peak_detection
+  CLASS PeakDetection
+  NAMESPACE puara_gestures::objects
   SOURCES
-    Puara/PeakDetection.hpp
+Puara/PeakDetection.hpp
     Puara/PeakDetection.cpp
     3rdparty/extras/PeakDetector.cpp
-    3rdparty/extras/PeakDetector.h
-  TARGET puara_peak_detection
-  MAIN_CLASS PeakDetection
-  NAMESPACE puara_gestures::objects
-)
+    3rdparty/extras/PeakDetector.h)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/RateOfChange.hpp
-    Puara/RateOfChange.cpp
-  TARGET puara_rate_of_change
-  MAIN_CLASS RateOfChange
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_rate_of_change
+  CLASS RateOfChange
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/RateOfChange.hpp
+    Puara/RateOfChange.cpp)
 
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/Roll.hpp
-    Puara/Roll.cpp
-  TARGET puara_roll
-  MAIN_CLASS Roll
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_roll
+  CLASS Roll
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/Roll.hpp
+    Puara/Roll.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/Tilt.hpp
-    Puara/Tilt.cpp
-  TARGET puara_tilt
-  MAIN_CLASS Tilt
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_tilt
+  CLASS Tilt
   NAMESPACE puara_gestures::objects
-)
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/Jab.hpp
-    Puara/Jab.cpp
-  TARGET puara_jab_1d
-  MAIN_CLASS Jab1D_Avnd
+Puara/Tilt.hpp
+    Puara/Tilt.cpp)
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_jab_1d
+  CLASS Jab1D_Avnd
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/Jab.hpp
+    Puara/Jab.cpp)
 
 
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/Binarizer.hpp
-    Puara/Binarizer.cpp
-  TARGET puara_binarizer
-  MAIN_CLASS Binarizer
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_binarizer
+  CLASS Binarizer
   NAMESPACE puara_gestures::objects
-)
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/Jab3D_Avnd.hpp
-    Puara/Jab3D_Avnd.cpp
-  TARGET puara_jab_3d_avnd
-  MAIN_CLASS Jab3D_Avnd
+Puara/Binarizer.hpp
+    Puara/Binarizer.cpp)
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_jab_3d_avnd
+  CLASS Jab3D_Avnd
   NAMESPACE puara_gestures::objects
-)
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/CompassAvnd.hpp
-    Puara/CompassAvnd.cpp
-  TARGET puara_compass_avnd
-  MAIN_CLASS CompassAvnd
+Puara/Jab3D_Avnd.hpp
+    Puara/Jab3D_Avnd.cpp)
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_compass_avnd
+  CLASS CompassAvnd
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/CompassAvnd.hpp
+    Puara/CompassAvnd.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/PCAAvnd.hpp
-    Puara/PCAAvnd.cpp
-  TARGET pca_avnd
-  MAIN_CLASS PCAAvnd
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME pca_avnd
+  CLASS PCAAvnd
   NAMESPACE puara_gestures::objects
-)
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/PowerBandEEGAvnd.hpp
-    Puara/PowerBandEEGAvnd.cpp
-  TARGET puara_powerband_eeg
-  MAIN_CLASS PowerBandEEGAvnd
+Puara/PCAAvnd.hpp
+    Puara/PCAAvnd.cpp)
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_powerband_eeg
+  CLASS PowerBandEEGAvnd
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/PowerBandEEGAvnd.hpp
+    Puara/PowerBandEEGAvnd.cpp)
 
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
-  SOURCES
-    Puara/Jab2D_Avnd.hpp
-    Puara/Jab2D_Avnd.cpp
-  TARGET puara_jab_2d_avnd
-  MAIN_CLASS Jab2D_Avnd
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_jab_2d_avnd
+  CLASS Jab2D_Avnd
   NAMESPACE puara_gestures::objects
-)
-avnd_score_plugin_add(
-  BASE_TARGET score_addon_puara
   SOURCES
-    Puara/Shake.hpp
-    Puara/Shake.cpp
-  TARGET puara_shake
-  MAIN_CLASS Shake
+Puara/Jab2D_Avnd.hpp
+    Puara/Jab2D_Avnd.cpp)
+avnd_addon_object(
+  BASE score_addon_puara
+  C_NAME puara_shake
+  CLASS Shake
   NAMESPACE puara_gestures::objects
-)
+  SOURCES
+Puara/Shake.hpp
+    Puara/Shake.cpp)
 
-avnd_score_plugin_finalize(
-  BASE_TARGET score_addon_puara
-  PLUGIN_VERSION 1
-  PLUGIN_UUID "049a40e0-01d9-4040-9d00-21f6931c3035"
-)
+avnd_addon_finalize(NAME score_addon_puara UUID 049a40e0-01d9-4040-9d00-21f6931c3035 VERSION 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,14 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 project(score_addon_puara LANGUAGES CXX)
 
+# Max/MSP externals link the static CRT (/MT) on Windows, as the official
+# max-sdk-base requires. Set it for the whole addon -- before Avendish and the
+# object library are created -- so every target shares one runtime; mixing /MT
+# and /MD trips MSVC with LNK2038. (CMP0091 is NEW via cmake_minimum_required.)
+if(MSVC)
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
+
 # Use the Avendish the host (ossia score) provides; otherwise fetch it.
 find_package(Avendish QUIET)
 if(NOT Avendish_FOUND)
@@ -9,7 +17,7 @@ if(NOT Avendish_FOUND)
   FetchContent_Declare(
     Avendish
     GIT_REPOSITORY "https://github.com/celtera/avendish"
-    GIT_TAG main)
+    GIT_TAG 7eafe173)
   FetchContent_Populate(Avendish)
   list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
   find_package(Avendish REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,16 @@ if(NOT TARGET xtensor)
   FetchContent_MakeAvailable(xtensor)
 endif()
 
+# BioData / extras call add_library() with no STATIC/SHARED keyword, so their
+# type follows BUILD_SHARED_LIBS. The score SDK build turns that ON, which made
+# them DLLs on Windows -- and their classes have no dllexport, so the final
+# score plugin failed to link (undefined Heart::* / SkinConductance::*). Force
+# them STATIC so their symbols are always available to whatever links them.
+set(_puara_prev_shared "${BUILD_SHARED_LIBS}")
+set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(3rdparty/BioData SYSTEM)
 add_subdirectory(3rdparty/extras SYSTEM)
+set(BUILD_SHARED_LIBS "${_puara_prev_shared}")
 
 # These static libs are linked into shared modules (pd / max / python / ...) in
 # standalone mode, so they must be position-independent. They also use C++17

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,16 @@ set_target_properties(BioData extras PROPERTIES
 # the object), so this only affects standalone / portability.
 set(PUARA_STANDALONE_BACKENDS
   dump ossia python pd max standalone wasm
-  touchdesigner:CHOP_MESSAGE godot:NODE)
+  touchdesigner:CHOP_MESSAGE)
+
+# The godot back-end produces a GDExtension. On Emscripten, godot-cpp's web
+# template forces a threaded (--shared-memory) link, but the object TUs aren't
+# built with -matomics/-mbulk-memory, so wasm-ld rejects them. Only emit the
+# godot back-end off-Emscripten; the plain `wasm` back-end still covers the web
+# portability surface.
+if(NOT EMSCRIPTEN)
+  list(APPEND PUARA_STANDALONE_BACKENDS godot:NODE)
+endif()
 
 avnd_addon_init(NAME score_addon_puara)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,15 +26,103 @@ endif()
 set(PUARA_GESTURES_ENABLE_TESTING OFF)
 set(PUARA_GESTURES_ENABLE_STANDALONE OFF)
 
-if(EXISTS 3rdparty/puara-gestures/3rdparty/boost)
-  file(REMOVE_RECURSE 3rdparty/puara-gestures/3rdparty/boost)
+# puara-gestures #includes <boost/...> (e.g. boost/circular_buffer.hpp via
+# rollingminmax.h). Boost must reach every target that compiles puara-gestures,
+# in BOTH build modes:
+#   - score mode: ossia score already provides Boost headers on its include path.
+#   - standalone / portability: the CI harness fetches a header-only Boost and
+#     passes -DBOOST_ROOT=... -DBoost_NO_BOOST_CMAKE=ON, so find_package(Boost)
+#     resolves it. The addon then attaches it to the base target, which the
+#     unified Avendish API propagates to the objects and every back-end.
+# We keep the vendored copy under 3rdparty/puara-gestures/3rdparty/boost as a
+# fallback include path (do NOT delete it) so the build still works when no
+# external Boost is provided.
+find_package(Boost QUIET)
+
+# A handful of objects (PowerBand, ERP, Correlation, PCA, Binarizer, Compass,
+# VAMP, PowerBandEEG, statistics/vamp algorithms) need Eigen + xtensor. ossia
+# score already provides those targets/headers; standalone does not, so fetch
+# the same stack score uses (xtl -> xsimd -> xtensor, plus Eigen3) when absent.
+# They are header-only, so this only costs a checkout, not a heavy build.
+if(NOT TARGET Eigen3::Eigen OR NOT TARGET xtensor)
+  include(FetchContent)
+  set(FETCHCONTENT_QUIET OFF)
+endif()
+
+if(NOT TARGET Eigen3::Eigen)
+  set(EIGEN_BUILD_DOC OFF CACHE BOOL "" FORCE)
+  set(EIGEN_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+  set(BUILD_TESTING OFF CACHE BOOL "" FORCE)
+  FetchContent_Declare(Eigen3
+    GIT_REPOSITORY "https://gitlab.com/libeigen/eigen"
+    GIT_TAG bc3b39870ecb690a623a3f49149a358b95c5781d
+    GIT_SHALLOW TRUE)
+  FetchContent_MakeAvailable(Eigen3)
+endif()
+
+if(NOT TARGET xtensor)
+  FetchContent_Declare(xtl
+    GIT_REPOSITORY "https://github.com/xtensor-stack/xtl"
+    GIT_TAG c52350e283b98e5d69dbc50726925a1f8e16c57c
+    GIT_SHALLOW TRUE)
+  FetchContent_MakeAvailable(xtl)
+  FetchContent_Declare(xsimd
+    GIT_REPOSITORY "https://github.com/xtensor-stack/xsimd"
+    GIT_TAG 6842624fc8adafd7168a999e7150b384411da448)
+  FetchContent_MakeAvailable(xsimd)
+  FetchContent_Declare(xtensor
+    GIT_REPOSITORY "https://github.com/xtensor-stack/xtensor"
+    GIT_TAG 18f6524829d8ac6399374f9ecbd21b959f75424d)
+  FetchContent_MakeAvailable(xtensor)
 endif()
 
 add_subdirectory(3rdparty/BioData SYSTEM)
 add_subdirectory(3rdparty/extras SYSTEM)
 
+# These static libs are linked into shared modules (pd / max / python / ...) in
+# standalone mode, so they must be position-independent.
+set_target_properties(BioData PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set_target_properties(extras PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
+
+# Standalone back-end set for every object. This is the data-processor preset
+# MINUS example_host: puara's objects define a custom tick (has_tick<T> is true),
+# which the pinned Avendish example_host binding can't drive (it calls the effect
+# with an integral tick and static_asserts !has_tick). Every other object
+# back-end builds fine. In a score build BACKENDS is ignored (score introspects
+# the object), so this only affects standalone / portability.
+set(PUARA_STANDALONE_BACKENDS
+  dump ossia python pd max standalone wasm
+  touchdesigner:CHOP_MESSAGE godot:NODE)
 
 avnd_addon_init(NAME score_addon_puara)
+
+# Make Boost reach the objects + back-ends through the base target. Only in
+# standalone: score already puts its own Boost on the global include path, and we
+# must not shadow it with a possibly-different external one. In standalone the
+# portability CI provides Boost via BOOST_ROOT; otherwise the vendored headers
+# (attached as an include dir below) cover it.
+if(NOT AVND_ADDON_SCORE AND Boost_FOUND)
+  if(TARGET Boost::headers)
+    target_link_libraries(score_addon_puara PUBLIC Boost::headers)
+  elseif(TARGET Boost::boost)
+    target_link_libraries(score_addon_puara PUBLIC Boost::boost)
+  elseif(Boost_INCLUDE_DIRS)
+    target_include_directories(score_addon_puara SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+  endif()
+endif()
+
+# Propagate Eigen + xtensor through the base target (objects + back-ends inherit
+# it). Only attach in standalone: in score mode these headers are already on the
+# global include path and the targets may carry score-specific settings.
+if(NOT AVND_ADDON_SCORE)
+  if(TARGET Eigen3::Eigen)
+    target_link_libraries(score_addon_puara PUBLIC Eigen3::Eigen)
+  endif()
+  if(TARGET xtensor)
+    target_link_libraries(score_addon_puara PUBLIC xtensor)
+  endif()
+endif()
 
 
 target_sources(score_addon_puara
@@ -83,8 +171,11 @@ target_sources(score_addon_puara
   Puara/statistics_algorithms.hpp
 )
 target_include_directories(score_addon_puara
-  PRIVATE
+  PUBLIC
   3rdparty/puara-gestures/include/
+  # Carries the vendored Boost fallback (3rdparty/.../3rdparty/boost) plus
+  # IMU_Sensor_Fusion. PUBLIC so the objects + back-ends that compile
+  # puara-gestures headers can resolve <boost/...> when no external Boost exists.
   3rdparty/puara-gestures/3rdparty/
 )
 target_link_libraries(score_addon_puara PUBLIC BioData)
@@ -94,6 +185,7 @@ avnd_addon_object(
   C_NAME puara_gesture
   CLASS GestureRecognizer
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/GestureRecognizer.hpp
     Puara/GestureRecognizer.cpp)
@@ -102,6 +194,7 @@ avnd_addon_object(
   C_NAME puara_powerband
   CLASS PowerBandAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/PowerBandAvnd.hpp
     Puara/PowerBandAvnd.cpp)
@@ -111,6 +204,7 @@ avnd_addon_object(
   C_NAME puara_erp_avnd
   CLASS ERPAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/ERPAvnd.hpp
     Puara/ERPAvnd.cpp)
@@ -119,6 +213,7 @@ avnd_addon_object(
   C_NAME puara_correlation_avnd
   CLASS CorrelationAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/CorrelationAvnd.hpp
     Puara/CorrelationAvnd.cpp)
@@ -128,6 +223,7 @@ avnd_addon_object(
   C_NAME puara_eda
   CLASS EdaRtFeatures
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/EdaRtFeatures.hpp
     Puara/EdaRtFeatures.cpp)
@@ -137,6 +233,7 @@ avnd_addon_object(
   C_NAME puara_heart
   CLASS BioData_Heart
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/BioDataHeart.hpp
     Puara/BioDataHeart.cpp)
@@ -146,6 +243,7 @@ avnd_addon_object(
   C_NAME puara_scaler
   CLASS Scaler
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Scaler.hpp
     Puara/Scaler.cpp)
@@ -155,6 +253,7 @@ avnd_addon_object(
   C_NAME puara_normalization
   CLASS Normalization
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Normalization.hpp
     Puara/Normalization.cpp)
@@ -164,6 +263,7 @@ avnd_addon_object(
   C_NAME smoother
   CLASS Smoother
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Smoother.hpp
     Puara/Smoother.cpp)
@@ -174,6 +274,7 @@ avnd_addon_object(
   C_NAME puara_button_avnd
   CLASS ButtonAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/ButtonAvnd.hpp
     Puara/ButtonAvnd.cpp)
@@ -183,6 +284,7 @@ avnd_addon_object(
   C_NAME walker_avnd
   CLASS WalkerAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/WalkerAvnd.hpp
     Puara/WalkerAvnd.cpp)
@@ -193,6 +295,7 @@ avnd_addon_object(
   C_NAME puara_skin_conductance
   CLASS BioData_Skin_Conductance
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/BioDataSkinConductance.hpp
     Puara/BioDataSkinConductance.cpp)
@@ -201,6 +304,7 @@ avnd_addon_object(
   C_NAME ClusteringAvnd
   CLASS ClusteringAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/ClusteringAvnd.hpp
     Puara/ClusteringAvnd.cpp)
@@ -209,6 +313,7 @@ avnd_addon_object(
   C_NAME vamp_avnd
   CLASS VAMPAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/VAMPAvnd.hpp
     Puara/VAMPAvnd.cpp)
@@ -218,6 +323,7 @@ avnd_addon_object(
   C_NAME puara_peak_detection
   CLASS PeakDetection
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/PeakDetection.hpp
     Puara/PeakDetection.cpp
@@ -229,6 +335,7 @@ avnd_addon_object(
   C_NAME puara_rate_of_change
   CLASS RateOfChange
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/RateOfChange.hpp
     Puara/RateOfChange.cpp)
@@ -239,6 +346,7 @@ avnd_addon_object(
   C_NAME puara_roll
   CLASS Roll
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Roll.hpp
     Puara/Roll.cpp)
@@ -248,6 +356,7 @@ avnd_addon_object(
   C_NAME puara_tilt
   CLASS Tilt
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Tilt.hpp
     Puara/Tilt.cpp)
@@ -256,6 +365,7 @@ avnd_addon_object(
   C_NAME puara_jab_1d
   CLASS Jab1D_Avnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Jab.hpp
     Puara/Jab.cpp)
@@ -267,6 +377,7 @@ avnd_addon_object(
   C_NAME puara_binarizer
   CLASS Binarizer
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Binarizer.hpp
     Puara/Binarizer.cpp)
@@ -275,6 +386,7 @@ avnd_addon_object(
   C_NAME puara_jab_3d_avnd
   CLASS Jab3D_Avnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Jab3D_Avnd.hpp
     Puara/Jab3D_Avnd.cpp)
@@ -283,6 +395,7 @@ avnd_addon_object(
   C_NAME puara_compass_avnd
   CLASS CompassAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/CompassAvnd.hpp
     Puara/CompassAvnd.cpp)
@@ -292,6 +405,7 @@ avnd_addon_object(
   C_NAME pca_avnd
   CLASS PCAAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/PCAAvnd.hpp
     Puara/PCAAvnd.cpp)
@@ -300,6 +414,7 @@ avnd_addon_object(
   C_NAME puara_powerband_eeg
   CLASS PowerBandEEGAvnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/PowerBandEEGAvnd.hpp
     Puara/PowerBandEEGAvnd.cpp)
@@ -309,6 +424,7 @@ avnd_addon_object(
   C_NAME puara_jab_2d_avnd
   CLASS Jab2D_Avnd
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Jab2D_Avnd.hpp
     Puara/Jab2D_Avnd.cpp)
@@ -317,6 +433,7 @@ avnd_addon_object(
   C_NAME puara_shake
   CLASS Shake
   NAMESPACE puara_gestures::objects
+  BACKENDS ${PUARA_STANDALONE_BACKENDS}
   SOURCES
 Puara/Shake.hpp
     Puara/Shake.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT Avendish_FOUND)
   FetchContent_Declare(
     Avendish
     GIT_REPOSITORY "https://github.com/celtera/avendish"
-    GIT_TAG 7eafe173)
+    GIT_TAG ebbbdf81a3c69831c50231877814b63852f9881c)
   FetchContent_Populate(Avendish)
   list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
   find_package(Avendish REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,9 +80,14 @@ add_subdirectory(3rdparty/BioData SYSTEM)
 add_subdirectory(3rdparty/extras SYSTEM)
 
 # These static libs are linked into shared modules (pd / max / python / ...) in
-# standalone mode, so they must be position-independent.
-set_target_properties(BioData PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set_target_properties(extras PROPERTIES POSITION_INDEPENDENT_CODE ON)
+# standalone mode, so they must be position-independent. They also use C++17
+# features (std::optional, std::clamp) but declare their own project() with no
+# standard, so they'd otherwise fall back to the compiler default -- which on
+# MSVC is C++14 and breaks the build. Pin them to C++20 like the rest of the addon.
+set_target_properties(BioData extras PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON)
 
 
 # Standalone back-end set for every object. This is the data-processor preset

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(NOT Avendish_FOUND)
   FetchContent_Declare(
     Avendish
     GIT_REPOSITORY "https://github.com/celtera/avendish"
-    GIT_TAG ebbbdf81a3c69831c50231877814b63852f9881c)
+    GIT_TAG fa0b8836b46723a15d89e06426f225f2431574db)
   FetchContent_Populate(Avendish)
   list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
   find_package(Avendish REQUIRED)

--- a/Puara/RateOfChange.hpp
+++ b/Puara/RateOfChange.hpp
@@ -58,10 +58,14 @@ public:
     // Time window (seconds) - visible when WindowMode::TimeWindow is selected
     halp::spinbox_f32<"Time window (s)", halp::range{0.001, 3600.0, 1.0}> time_window;
 
-    // Output units using combobox style
+    // Output units selector. Uses halp__enum (a plain string_view[] array of
+    // labels) rather than halp__enum_combobox: the combobox macro builds a
+    // std::pair<std::string_view, enum_type>[] aggregate that MSVC (notably the
+    // arm64 toolchain) rejects with C2440. Same enum values + labels, only the
+    // default widget hint differs.
     struct
     {
-      halp__enum_combobox(
+      halp__enum(
           "Output units",
           PerSecond, // default
           PerMillisecond, PerSecond, PerMinute, PerHour)


### PR DESCRIPTION
Migrates to the unified Avendish addon CMake (celtera/avendish#97): ScoreExternalAddon bootstrap + the 26 avnd_score_plugin_* calls → find_package(Avendish) (host-aware) + avnd_addon_init/object/finalize. The bundled BioData/extras/puara-gestures subdirs, target_sources/include_directories and the BioData link on the base target are unchanged. Requires score's avendish submodule to include #97 (ossia/score#2075).