### PR TITLE
chore: track avendish 558744d (CMake-native packaging default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT Avendish_FOUND)
   FetchContent_Declare(
     Avendish
     GIT_REPOSITORY "https://github.com/celtera/avendish"
-    GIT_TAG 82c034b865efe7eb2bd74f14ae6ec30ed027948d)
+    GIT_TAG 558744dcd18657163a1d6955ed9992188e00e8ad)
   FetchContent_Populate(Avendish)
   list(APPEND CMAKE_PREFIX_PATH "${avendish_SOURCE_DIR}")
   find_package(Avendish REQUIRED)


### PR DESCRIPTION
## What

Track the latest Avendish `main` (`celtera/avendish@558744d`).

## Why

As of `558744d`, `avnd_addon_finalize` makes CMake-native addon packaging the
default: in a standalone (non-score) build it assembles the per-backend
distributable packages automatically — externals + the generated Max/Pd
help & example patches + LICENSE/README — with no per-addon packaging code.

## Validation

Built standalone against `avendish@558744d` with clang 20 (Boost 1.90): the
object bindings compile, link, and package with their generated help patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Z4KK2Rays9dTj8J2AJcFZ
