### PR TITLE
ci: use Opus and allow build tools for Claude Code

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,13 +36,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Customize the trigger phrase (default: @claude)
-          # trigger_phrase: "/claude"
-
-          # Optional: Trigger when specific user is assigned to an issue
-          # assignee_trigger: "claude-bot"
-
-          # Optional: Configure Claude's behavior with CLI arguments
-          # claude_args: |
-          #   --model claude-opus-4-1-20250805
-          #   --max-turns 10
+          claude_args: |
+            --model opus
+            --max-turns 15
+            --allowedTools "WebFetch,WebSearch,Bash(cmake:*),Bash(ninja:*),Bash(ctest:*),Bash(clang-format:*),Bash(pkg-config:*)"


### PR DESCRIPTION
Configures the Claude Code action:

- `--model opus`
- `--max-turns 15` to bound cost
- `--allowedTools` for read-only web plus this repo's build/test commands

Bash is not enabled by default in the action; these scoped entries let `@claude` actually build and test rather than guess. Only users with write access can trigger the action. Commit tagged `[skip ci]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)