### PR TITLE
Require CMake 3.25 so Max externals build /MT (fixes Max startup crash)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,17 @@
-cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
 
 project(score_addon_puara LANGUAGES CXX)
 
 # Max/MSP externals link the static CRT (/MT) on Windows, as the official
 # max-sdk-base requires. Set it for the whole addon -- before Avendish and the
 # object library are created -- so every target shares one runtime; mixing /MT
-# and /MD trips MSVC with LNK2038. (CMP0091 is NEW via cmake_minimum_required.)
+# and /MD trips MSVC with LNK2038.
+#
+# CMAKE_MSVC_RUNTIME_LIBRARY only takes effect when policy CMP0091 is NEW, which
+# is only the default from CMake 3.15 on: under the previous 3.13 minimum the
+# setting was silently ignored and every target -- Max externals included --
+# built /MD, which corrupts Max's heap at load. The 3.25 minimum above makes
+# CMP0091 NEW so the /MT request is honoured.
 #
 # Only for the standalone build: inside a score build the Max backend is not
 # emitted, and score links the dynamic CRT (/MD). Forcing /MT here would make


### PR DESCRIPTION
The Max externals in the `continuous` artifacts link the **dynamic** CRT (`/MD`), but max-sdk-base requires the **static** CRT (`/MT`). A `/MD` external has its own CRT heap, which corrupts Max's heap when memory crosses the Max↔external boundary — reproduced as an access violation (`0xC0000005`) in `ntdll.dll` heap code, crashing **Max 8 at startup** once the package is indexed.

Root cause: the addon already sets `CMAKE_MSVC_RUNTIME_LIBRARY` to `/MT`, but that property only takes effect when policy **CMP0091 is NEW**, which is the default only from **CMake 3.15** on. Under the previous `cmake_minimum_required(3.13)` the setting was silently ignored and every target — Max externals included — built `/MD`.

Verified with a minimal experiment: `cmake_minimum_required(3.13)` + the runtime setting → `/MD`; adding `cmake_policy(SET CMP0091 NEW)` → `/MT`.

Raising the minimum to 3.25 (matching Avendish) makes CMP0091 NEW so the `/MT` request is honoured for the shared base library, `BioData`/`extras`, and every backend uniformly (a single global choice, since the shared object library is linked into all backends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)