### PR TITLE
build: stop the vendored Boost shadowing the one score provides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,11 +206,39 @@ target_sources(score_addon_puara
 target_include_directories(score_addon_puara
   PUBLIC
   3rdparty/puara-gestures/include/
-  # Carries the vendored Boost fallback (3rdparty/.../3rdparty/boost) plus
-  # IMU_Sensor_Fusion. PUBLIC so the objects + back-ends that compile
-  # puara-gestures headers can resolve <boost/...> when no external Boost exists.
-  3rdparty/puara-gestures/3rdparty/
 )
+
+# IMU_Sensor_Fusion is included as <IMU_Sensor_Fusion/imu_orientation.h>, so its
+# parent directory has to be on the include path. That parent also holds a
+# complete vendored Boost, and exposing it means every <boost/...> these targets
+# reach - including the ones they never asked for, pulled in through score's own
+# headers - resolves there rather than to the Boost everything else is built
+# against. Two Boost versions then meet in one link, sharing mangled names
+# without sharing definitions, which is an ODR violation whatever it happens to
+# do at link time. It bit as an undefined
+# boost::asio::detail::winsock_init_base::startup once libossia moved to Boost
+# 1.91 and began versioning Asio's symbols: score's Asio was namespaced, the
+# vendored 1.86 had no such notion.
+#
+# So when an external Boost exists, expose IMU_Sensor_Fusion on its own, through
+# a directory in the build tree that holds nothing else. The vendored tree stays
+# where it is and still covers the case it was meant for - no external Boost at
+# all - where it is the only Boost in the build and cannot shadow anything.
+#
+# Prepending the external Boost instead does not work: it is already on these
+# targets as a SYSTEM directory, inherited from score, and -isystem paths are
+# searched after -I ones, so it loses to the vendored directory no matter where
+# it is declared.
+if(Boost_INCLUDE_DIR)
+  set(PUARA_IMU_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/puara-3rdparty-include")
+  file(COPY
+    "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/puara-gestures/3rdparty/IMU_Sensor_Fusion"
+    DESTINATION "${PUARA_IMU_INCLUDE_DIR}")
+  target_include_directories(score_addon_puara PUBLIC "${PUARA_IMU_INCLUDE_DIR}")
+else()
+  target_include_directories(score_addon_puara PUBLIC 3rdparty/puara-gestures/3rdparty/)
+endif()
+
 target_link_libraries(score_addon_puara PUBLIC BioData)
 
 avnd_addon_object(


### PR DESCRIPTION
`IMU_Sensor_Fusion` is included as `<IMU_Sensor_Fusion/imu_orientation.h>`, so its parent directory has to be on the include path. That parent also holds a complete **vendored Boost 1.86**, and exposing it means every `<boost/...>` these targets reach resolves there — including the headers they never asked for, pulled in transitively through score's own.

So a score build has been compiling this addon against a **different Boost** than everything it links with.

## Why it matters

Two Boost versions in one binary share mangled names without sharing definitions. That's an ODR violation whatever it happens to do at link time — and until now it happened to link, because both spelled the symbols the same way.

It stopped once libossia moved to Boost 1.91 and began versioning Asio's global symbols (ossia/libossia#917). score's Asio is namespaced; the vendored 1.86 has no such notion:

```
lld-link : error : undefined symbol:
  boost::asio::detail::winsock_init_base::startup(...)
  >>> referenced by score_addon_puara.lib(unity_0_cxx.obj)
```

## The change

When an external Boost exists, expose `IMU_Sensor_Fusion` on its own, through a build-tree directory that holds nothing else. The vendored tree stays where it is and still covers the case it was written for — no external Boost at all — where it's the only Boost in the build and can't shadow anything.

`puara-gestures` is untouched.

## What does not work, worth recording

Prepending the external Boost with `BEFORE`:

| entry | how it lands |
|---|---|
| vendored `puara-gestures/3rdparty` | `-I`, position 9 |
| score's `boost_1_91_0` | `-isystem`, position 68 |

It's already on these targets as a SYSTEM directory inherited from score, and `-isystem` paths are searched after `-I` ones — so it loses to the vendored directory no matter where it's declared.

## Verified

Building score against Boost 1.91 with `BOOST_ASIO_ENABLE_VERSION_NAMESPACE`:

- vendored directory no longer on the addon's include path; `IMU_Sensor_Fusion` still reachable
- addon compiles with **zero** Boost/Asio diagnostics
- `score.exe` links with **zero** undefined symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGta2LPAedDP3Txvyq8kTW